### PR TITLE
Add mongoose returns and attendance features

### DIFF
--- a/mongoose/controllers/attendanceCRUDController.js
+++ b/mongoose/controllers/attendanceCRUDController.js
@@ -1,0 +1,37 @@
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+
+exports.createAttendance = async (req,res,next)=>{
+  try {
+    const { date, locationId, projectId, employeeId, subcontractorId, type, hoursWorked, dayRate } = req.body;
+    if(locationId && projectId) return res.status(400).send('Only location or project allowed');
+    if(!locationId && !projectId) return res.status(400).send('Location or project required');
+    if(hoursWorked && dayRate) return res.status(400).send('Hours or dayRate only');
+    const attendance = await mdb.attendance.create({ date, locationId:locationId||null, projectId:projectId||null, employeeId:employeeId||null, subcontractorId:subcontractorId||null, type, hoursWorked:hoursWorked||null, dayRate:dayRate||null });
+    res.json({attendance});
+  }catch(err){ next(err); }
+};
+
+exports.readAttendance = async (req,res,next)=>{
+  try {
+    const attendance = await mdb.attendance.findOne({ uuid: req.params.uuid }).populate('employeeId subcontractorId locationId');
+    if(!attendance) return res.status(404).send('Not found');
+    res.json({attendance});
+  }catch(err){ next(err); }
+};
+
+exports.updateAttendance = async (req,res,next)=>{
+  try {
+    const { date, locationId, projectId, employeeId, subcontractorId, type, hoursWorked, dayRate } = req.body;
+    const update = { date, locationId:locationId||null, projectId:projectId||null, employeeId:employeeId||null, subcontractorId:subcontractorId||null, type, hoursWorked:employeeId?hoursWorked||null:null, dayRate:dayRate||null };
+    const attendance = await mdb.attendance.findOneAndUpdate({ uuid:req.params.uuid }, update, { new:true });
+    if(!attendance) return res.status(404).send('Not found');
+    res.json({attendance});
+  }catch(err){ next(err); }
+};
+
+exports.deleteAttendance = async (req,res,next)=>{
+  try {
+    await mdb.attendance.findOneAndDelete({ uuid:req.params.uuid });
+    res.json({success:true});
+  }catch(err){ next(err); }
+};

--- a/mongoose/controllers/dailyAttendanceController.js
+++ b/mongoose/controllers/dailyAttendanceController.js
@@ -1,0 +1,18 @@
+const moment = require('moment');
+const path = require('path');
+const attendanceService = require('../../services/mongoose/attendanceServicesMongoose');
+
+exports.getDailyAttendance = async (req,res,next)=>{
+  const date = req.params.date || moment().format('YYYY-MM-DD');
+  try {
+    const attendance = await attendanceService.getAttendanceForDay(date);
+    res.render(path.join('mongoose','dailyAttendance'),{
+      moment,
+      attendance,
+      date,
+      currentTab:'daily'
+    });
+  }catch(err){
+    next(err);
+  }
+};

--- a/mongoose/controllers/employeeCRUDController.js
+++ b/mongoose/controllers/employeeCRUDController.js
@@ -1,0 +1,32 @@
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+
+exports.createEmployee = async (req,res,next)=>{
+  try {
+    const data = req.body;
+    const emp = await mdb.employee.create(data);
+    res.json({employee:emp});
+  }catch(err){ next(err); }
+};
+
+exports.readEmployee = async (req,res,next)=>{
+  try {
+    const emp = await mdb.employee.findOne({ uuid:req.params.uuid });
+    if(!emp) return res.status(404).send('Not found');
+    res.json({employee:emp});
+  }catch(err){ next(err); }
+};
+
+exports.updateEmployee = async (req,res,next)=>{
+  try {
+    const emp = await mdb.employee.findOneAndUpdate({ uuid:req.params.uuid }, req.body, { new:true });
+    if(!emp) return res.status(404).send('Not found');
+    res.json({employee:emp});
+  }catch(err){ next(err); }
+};
+
+exports.deleteEmployee = async (req,res,next)=>{
+  try {
+    await mdb.employee.findOneAndDelete({ uuid:req.params.uuid });
+    res.json({success:true});
+  }catch(err){ next(err); }
+};

--- a/mongoose/controllers/locationCRUDController.js
+++ b/mongoose/controllers/locationCRUDController.js
@@ -1,0 +1,31 @@
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+
+exports.createLocation = async (req,res,next)=>{
+  try {
+    const loc = await mdb.location.create(req.body);
+    res.json({location:loc});
+  }catch(err){ next(err); }
+};
+
+exports.readLocation = async (req,res,next)=>{
+  try {
+    const loc = await mdb.location.findOne({ uuid:req.params.uuid });
+    if(!loc) return res.status(404).send('Not found');
+    res.json({location:loc});
+  }catch(err){ next(err); }
+};
+
+exports.updateLocation = async (req,res,next)=>{
+  try {
+    const loc = await mdb.location.findOneAndUpdate({ uuid:req.params.uuid }, req.body, { new:true });
+    if(!loc) return res.status(404).send('Not found');
+    res.json({location:loc});
+  }catch(err){ next(err); }
+};
+
+exports.deleteLocation = async (req,res,next)=>{
+  try {
+    await mdb.location.findOneAndDelete({ uuid:req.params.uuid });
+    res.json({success:true});
+  }catch(err){ next(err); }
+};

--- a/mongoose/controllers/monthlyReturnsController.js
+++ b/mongoose/controllers/monthlyReturnsController.js
@@ -1,0 +1,89 @@
+const path = require('path');
+const moment = require('moment');
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+const normalizePayments = require('../../services/kashflowNormalizer').normalizePayments;
+
+const monthNames = [
+  'April','May','June','July','August','September',
+  'October','November','December','January','February','March'
+];
+
+exports.renderMonthlyReturnsForm = async (req,res,next)=>{
+  try {
+    const suppliers = await mdb.supplier.find({ IsSubcontractor: true }).lean();
+    const suppliersWithMonths = [];
+    for (const supplier of suppliers) {
+      const recs = await mdb.receipt.find({ CustomerID: supplier.SupplierID })
+        .select('TaxYear TaxMonth')
+        .lean();
+      const receiptsByYear = {};
+      recs.forEach(r=>{
+        if(!r.TaxYear || !r.TaxMonth) return;
+        if(!receiptsByYear[r.TaxYear]) receiptsByYear[r.TaxYear]=[];
+        if(!receiptsByYear[r.TaxYear].includes(r.TaxMonth)) {
+          receiptsByYear[r.TaxYear].push(r.TaxMonth);
+          receiptsByYear[r.TaxYear].sort((a,b)=>monthNames.indexOf(monthNames[a-1]) - monthNames.indexOf(monthNames[b-1]));
+        }
+      });
+      suppliersWithMonths.push({
+        supplier,
+        years:Object.keys(receiptsByYear).sort((a,b)=>b-a),
+        receiptsByYear
+      });
+    }
+    res.render(path.join('mongoose','monthlyReturnsForm'),{
+      title:'Monthly Returns Form',
+      suppliersWithMonths,
+      monthNames
+    });
+  }catch(err){
+    next(err);
+  }
+};
+
+exports.renderMonthlyReturns = async (req,res,next)=>{
+  try {
+    const { month, year, uuid } = req.params;
+    if(!month || !year || !uuid) return res.status(400).send('Month, Year and Supplier UUID required');
+    const supplier = await mdb.supplier.findOne({ uuid }).lean();
+    if(!supplier) return res.status(404).send('Supplier not found');
+    const receipts = await mdb.receipt.find({ CustomerID: supplier.SupplierID, TaxYear: year, TaxMonth: month }).sort({ InvoiceNumber: 1 }).lean();
+    const receiptsByMonth = {};
+    receipts.forEach(receipt=>{
+      const m = receipt.TaxMonth || moment(receipt.InvoiceDate).month()+1;
+      if(!receiptsByMonth[m]) receiptsByMonth[m]=[];
+      const lines = Array.isArray(receipt.Lines) ? receipt.Lines : (receipt.Lines?.Line ? (Array.isArray(receipt.Lines.Line)?receipt.Lines.Line:[receipt.Lines.Line]) : []);
+      const payments = normalizePayments(receipt.Payments, receipt.InvoiceNumber, receipt.CustomerID);
+      const labourCost = lines.filter(l=>l.ChargeType===18685897).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0);
+      const materialCost = lines.filter(l=>l.ChargeType===18685896).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0);
+      const cisAmount = Math.abs(lines.filter(l=>l.ChargeType===18685964).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0));
+      const grossAmount = labourCost + materialCost;
+      const netAmount = grossAmount - cisAmount;
+      const payDates = payments?.Payment?.Payment?.map(p=>p.PayDate) || [];
+      const payDate = payDates.length>0 ? payDates[0] : 'N/A';
+      receiptsByMonth[m].push({
+        InvoiceNumber: receipt.CustomerReference,
+        KashflowNumber: receipt.InvoiceNumber,
+        InvoiceDate: receipt.InvoiceDate,
+        PayDates: payDates,
+        PayDate: payDate,
+        GrossAmount: grossAmount,
+        LabourCost: labourCost,
+        MaterialCost: materialCost,
+        CISAmount: cisAmount,
+        NetAmount: netAmount,
+        SubmissionDate: receipt.SubmissionDate
+      });
+    });
+    res.render(path.join('mongoose','monthlyReturnsForOneSubcontractor'),{
+      title:'Subcontractor Monthly Returns',
+      year,
+      supplier,
+      receiptsByMonth,
+      monthNames,
+      pageBreakMonths:[]
+    });
+  }catch(err){
+    next(err);
+  }
+};

--- a/mongoose/controllers/weeklyAttendanceController.js
+++ b/mongoose/controllers/weeklyAttendanceController.js
@@ -1,0 +1,49 @@
+const moment = require('moment-timezone');
+const path = require('path');
+const attendanceService = require('../../services/mongoose/attendanceServicesMongoose');
+const taxService = require('../../services/taxService');
+
+exports.getWeeklyAttendance = async (req,res,next)=>{
+  try {
+    const yearParam = parseInt(req.params.year);
+    const weekParam = parseInt(req.params.week);
+    const year = !isNaN(yearParam) ? yearParam : taxService.getCurrentTaxYear();
+    const { start: startOfTaxYear, end: endOfTaxYear } = taxService.getTaxYearStartEnd(year);
+    const taxYearStart = moment.tz(startOfTaxYear,'Do MMMM YYYY','Europe/London');
+    const taxYearEnd = moment.tz(endOfTaxYear,'Do MMMM YYYY','Europe/London');
+    let firstPayrollWeekStart = taxYearStart.clone().day(6);
+    if(firstPayrollWeekStart.isBefore(taxYearStart)) firstPayrollWeekStart.add(7,'days');
+    const totalWeeksInYear = taxYearEnd.diff(firstPayrollWeekStart,'weeks')+1;
+    const today = moment.tz('Europe/London');
+    let requestedWeekNumber = !isNaN(weekParam)?weekParam:today.diff(firstPayrollWeekStart,'weeks')+1;
+    if(requestedWeekNumber<1) requestedWeekNumber=1;
+    if(requestedWeekNumber>totalWeeksInYear) requestedWeekNumber=totalWeeksInYear;
+    const payrollWeekStart = firstPayrollWeekStart.clone().add((requestedWeekNumber-1)*7,'days');
+    const endDate = payrollWeekStart.clone().add(6,'days');
+    const previousWeek = requestedWeekNumber===1?totalWeeksInYear:requestedWeekNumber-1;
+    const previousYear = requestedWeekNumber===1?year-1:year;
+    const nextWeek = requestedWeekNumber===totalWeeksInYear?1:requestedWeekNumber+1;
+    const nextYear = requestedWeekNumber===totalWeeksInYear?year+1:year;
+    const { attendanceRecords, employeeCount, subcontractorCount, allEmployees, allSubcontractors, paidReceipts } = await attendanceService.getAttendanceForWeek(payrollWeekStart,endDate);
+    const { groupedAttendance, totalEmployeeHours, totalEmployeePay, totalSubcontractorPay, daysOfWeek } = attendanceService.groupAttendanceByPerson(attendanceRecords,payrollWeekStart,endDate,allEmployees,allSubcontractors,paidReceipts);
+    res.render(path.join('mongoose','weeklyAttendance'),{
+      moment,
+      groupedAttendance,
+      startDate: payrollWeekStart.format('YYYY-MM-DD'),
+      endDate: endDate.format('YYYY-MM-DD'),
+      previousYear,
+      previousWeek,
+      nextYear,
+      nextWeek,
+      employeeCount,
+      subcontractorCount,
+      totalEmployeePay,
+      totalEmployeeHours,
+      totalSubcontractorPay,
+      currentTab:'weekly',
+      daysOfWeek
+    });
+  }catch(err){
+    next(err);
+  }
+};

--- a/mongoose/controllers/yearlyReturnsController.js
+++ b/mongoose/controllers/yearlyReturnsController.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const moment = require('moment');
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+const { normalizePayments } = require('../../services/kashflowNormalizer');
+const monthNames = [
+  'April','May','June','July','August','September',
+  'October','November','December','January','February','March'
+];
+
+exports.renderYearlyReturns = async (req,res,next)=>{
+  try {
+    const { year, uuid } = req.params;
+    if(!year || !uuid) return res.status(400).send('Year and Supplier UUID required');
+    const supplier = await mdb.supplier.findOne({ uuid }).lean();
+    if(!supplier) return res.status(404).send('Supplier not found');
+    const receipts = await mdb.receipt.find({ CustomerID: supplier.SupplierID, TaxYear: year }).sort({ InvoiceNumber:1 }).lean();
+    const receiptsByMonth = {};
+    receipts.forEach(receipt=>{
+      const m = receipt.TaxMonth || moment(receipt.InvoiceDate).month()+1;
+      if(!receiptsByMonth[m]) receiptsByMonth[m]=[];
+      const lines = Array.isArray(receipt.Lines)?receipt.Lines:(receipt.Lines?.Line?(Array.isArray(receipt.Lines.Line)?receipt.Lines.Line:[receipt.Lines.Line]):[]);
+      const payments = normalizePayments(receipt.Payments, receipt.InvoiceNumber, receipt.CustomerID);
+      const labourCost = lines.filter(l=>l.ChargeType===18685897).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0);
+      const materialCost = lines.filter(l=>l.ChargeType===18685896).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0);
+      const cisAmount = Math.abs(lines.filter(l=>l.ChargeType===18685964).reduce((s,l)=>s+((+l.Rate)*(+l.Quantity)||0),0));
+      const grossAmount = labourCost + materialCost;
+      const netAmount = grossAmount - cisAmount;
+      const payDates = payments?.Payment?.Payment?.map(p=>p.PayDate) || [];
+      receiptsByMonth[m].push({
+        InvoiceNumber: receipt.CustomerReference,
+        KashflowNumber: receipt.InvoiceNumber,
+        InvoiceDate: receipt.InvoiceDate,
+        PayDate: payDates[0] || 'N/A',
+        Gross: grossAmount,
+        Labour: labourCost,
+        Material: materialCost,
+        CIS: cisAmount,
+        Net: netAmount,
+        Submission: receipt.SubmissionDate
+      });
+    });
+    res.render(path.join('mongoose','yearlyReturns'),{
+      title:'Subcontractor Yearly Returns',
+      year,
+      supplier,
+      receiptsByMonth,
+      monthNames,
+      pageBreakMonths:[]
+    });
+  }catch(err){
+    next(err);
+  }
+};

--- a/mongoose/routes/attendanceCrud.js
+++ b/mongoose/routes/attendanceCrud.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/attendanceCRUDController');
+
+router.post('/attendance/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createAttendance);
+router.get('/attendance/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readAttendance);
+router.post('/attendance/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateAttendance);
+router.post('/attendance/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteAttendance);
+
+module.exports = router;

--- a/mongoose/routes/dailyAttendance.js
+++ b/mongoose/routes/dailyAttendance.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/dailyAttendanceController');
+
+router.get('/attendance/daily/:date?', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.getDailyAttendance);
+
+module.exports = router;

--- a/mongoose/routes/employeeCrud.js
+++ b/mongoose/routes/employeeCrud.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/employeeCRUDController');
+
+router.post('/employee/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createEmployee);
+router.get('/employee/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readEmployee);
+router.post('/employee/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateEmployee);
+router.post('/employee/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteEmployee);
+
+module.exports = router;

--- a/mongoose/routes/locationCrud.js
+++ b/mongoose/routes/locationCrud.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/locationCRUDController');
+
+router.post('/location/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createLocation);
+router.get('/location/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readLocation);
+router.post('/location/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateLocation);
+router.post('/location/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteLocation);
+
+module.exports = router;

--- a/mongoose/routes/monthlyReturns.js
+++ b/mongoose/routes/monthlyReturns.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/monthlyReturnsController');
+
+router.get('/monthly/returns/form', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderMonthlyReturnsForm);
+router.get('/monthly/returns/:month/:year/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderMonthlyReturns);
+
+module.exports = router;

--- a/mongoose/routes/weeklyAttendance.js
+++ b/mongoose/routes/weeklyAttendance.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/weeklyAttendanceController');
+
+router.get('/attendance/weekly', auth.ensureAuthenticated, auth.ensureRole('admin'), (req,res,next)=>{
+  const currentYear = require('../../services/taxService').getCurrentTaxYear();
+  res.redirect(`/attendance/weekly/${currentYear}`);
+});
+router.get('/attendance/weekly/:year?/:week?', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.getWeeklyAttendance);
+
+module.exports = router;

--- a/mongoose/routes/yearlyReturns.js
+++ b/mongoose/routes/yearlyReturns.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/mongoose/authServiceMongoose');
+const ctrl = require('../controllers/yearlyReturnsController');
+
+router.get('/yearly/returns/:year/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderYearlyReturns);
+
+module.exports = router;

--- a/mongoose/views/mongoose/dailyAttendance.ejs
+++ b/mongoose/views/mongoose/dailyAttendance.ejs
@@ -1,0 +1,95 @@
+
+
+<div class="container py-4">
+    <div class="mb-4 bg-body-tertiary rounded-3">
+        <!-- Vertical Navigation Tabs for Daily, Weekly, Monthly -->
+        <ul class="nav nav-tabs justify-content-center mb-4">
+            <li class="nav-item">
+                <a href="/attendance/daily" class="nav-link <%= currentTab === 'daily' ? 'active' : '' %>">Daily</a>
+            </li>
+            <li class="nav-item">
+                <a href="/attendance/weekly" class="nav-link <%= currentTab === 'weekly' ? 'active' : '' %>">Weekly</a>
+            </li>
+        </ul>
+
+        <div class="container-fluid py-5">
+            <h1 class="display-5 fw-bold text-center">Daily Attendance for <%= moment(date).format('Do MMMM YYYY') %></h1>
+            <table class="table table-bordered table-striped">
+                <thead>
+                    <tr>
+                        <th>Location</th>
+                        <th>Person</th>
+                        <th>Type</th>
+                        <th>Hours Worked</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <% if (attendance.length > 0) { %>
+                        <% attendance.forEach(record => { %>
+                            <tr>
+                                <!-- Location Column -->
+                                <td>
+                                    <% if (record.Location) { %>
+                                        <a href="/location/read/<%= record.Location.id %>">
+                                            <%= record.Location.name || `${record.Location.address}, ${record.Location.city}, ${record.Location.postalCode}` %>
+                                        </a>
+                                    <% } else { %>
+                                        N/A
+                                    <% } %>
+                                </td>
+                                
+                                <!-- Person Column (Either Employee or Subcontractor) -->
+                                <td>
+                                    <% if (record.Employee) { %>
+                                        <a href="/employee/read/<%= record.Employee.id %>"><%= record.Employee.name %></a>
+                                    <% } else if (record.Subcontractor) { %>
+                                        <a href="/subcontractor/read/<%= record.Subcontractor.id %>"><%= record.Subcontractor.company %></a>
+                                    <% } else { %>
+                                        N/A
+                                    <% } %>
+                                </td>
+
+                                <!-- Type of Attendance (ENUM) -->
+                                <td><%= record.type || 'N/A' %></td>
+
+                                <!-- Hours Worked (if available for the Employee) -->
+                                <td>
+                                    <% if (record.hoursWorked) { %>
+                                        <%= record.hoursWorked %> hours
+                                    <% } else { %>
+                                        N/A
+                                    <% } %>
+                                </td>
+
+                                <!-- Actions Column -->
+                                <td class="text-center">
+                                    <!-- Link to view the record in more detail -->
+                                    <a href="/attendance/read/<%= record.id %>" class="btn btn-hcs-green btn-sm">
+                                        <i class="bi bi-eye"></i>
+                                    </a>
+
+                                    <!-- Link to update the attendance record -->
+                                    <a href="/attendance/update/<%= record.id %>" class="btn btn-secondary btn-sm">
+                                        <i class="bi bi-pencil-square"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        <% }); %>
+                    <% } else { %>
+                        <tr>
+                            <td colspan="5" class="text-center">No attendance records found for this day.</td>
+                        </tr>
+                    <% } %>
+                    <tr class="fw-light">
+                        <td>
+                            <button class="btn btn-hcs-green" style="transform: rotate(0);">
+                                <a href="/attendance/create?date=<%= date %>" class="text-white stretched-link text-decoration-none">+</a>
+                            </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/mongoose/views/mongoose/monthlyReturnsForAll.ejs
+++ b/mongoose/views/mongoose/monthlyReturnsForAll.ejs
@@ -1,0 +1,141 @@
+<div class="text-center mt-4">
+    <h1 class="mb-4">Month <%= month %> Report</h1>
+    <% subcontractors.forEach(subcontractor => { %>
+        <div>
+            <%= subcontractor.name %> | <%= subcontractor.company %> @ <% if (subcontractor.deduction === 0.0) { %>
+                0%
+            <% } else if (subcontractor.deduction === 0.2) { %>
+                20%
+            <% } else if (subcontractor.deduction === 0.3) { %>
+                30%
+            <% } %>
+            <% if (subcontractor.isGross) { %>
+                GROSS
+            <% } %>
+            <br>
+            <%= subcontractor.utrNumber %> | <%= subcontractor.cisNumber %>
+        </div>
+        <div class="container">
+            <% const hasInvoices = subcontractor.invoices.length > 0; %>
+            <% if (hasInvoices) { %>
+                <table class="table table-hover table-sm caption-top">
+                    <caption class="text-start">Month <%= month %></caption>
+                    <thead>
+                        <tr>
+                            <th>
+                                <span class="d-none d-md-table-cell">Invoice</span>
+                                <span class="d-md-none">Inv</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Kashflow</span>
+                                <span class="d-md-none">KF</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Invoiced</span>
+                                <span class="d-md-none">Invoiced</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Paid</span>
+                                <span class="d-md-none">Paid</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Gross</span>
+                                <span class="d-md-none">Gross</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Labour</span>
+                                <span class="d-md-none">Labour</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Material</span>
+                                <span class="d-md-none">Material</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">CIS @ <% if (subcontractor.deduction === 0.0) { %>
+                                        0%
+                                    <% } else if (subcontractor.deduction === 0.2) { %>
+                                        20%
+                                    <% } else if (subcontractor.deduction === 0.3) { %>
+                                        30%
+                                    <% } %>
+                                </span>
+                                <span class="d-md-none">CIS</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Net</span>
+                                <span class="d-md-none">Net</span>
+                            </th>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <th>
+                                    <span class="d-none d-md-table-cell">Reverse Charge</span>
+                                    <span class="d-md-none">RC</span>
+                                </th>
+                            <% } %>
+                            <th>Month</th>
+                            <th>Year</th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Submission Date</span>
+                                <span class="d-md-none">Submission</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="table-group-divider">
+                        <% let totalGross = 0; %>
+                        <% let totalLabourCost = 0; %>
+                        <% let totalMaterialCost = 0; %>
+                        <% let totalCISAmount = 0; %>
+                        <% let totalNetAmount = 0; %>
+                        <% let totalReverseCharge = 0; %>
+                        <% subcontractor.invoices.forEach(invoice => { %>
+                        <tr>
+                            <td><%= invoice.invoiceNumber %></td>
+                            <td><%= invoice.kashflowNumber %></td>
+                            <td><%= slimDateTime(invoice.invoiceDate) %></td>
+                            <td><%= slimDateTime(invoice.remittanceDate) %></td>
+                            <td><%= formatCurrency(invoice.grossAmount) %></td>
+                            <td><%= formatCurrency(invoice.labourCost) %></td>
+                            <td><%= formatCurrency(invoice.materialCost) %></td>
+                            <td><%= formatCurrency(invoice.cisAmount) %></td>
+                            <td><%= formatCurrency(invoice.netAmount) %></td>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <td><%= formatCurrency(invoice.reverseCharge) %></td>
+                            <% } %>
+                            <td><%= invoice.month %></td>
+                            <td><%= invoice.year %></td>
+                            <td><%= slimDateTime(invoice.submissionDate) %></td>
+                        </tr>
+                        <% totalGross += invoice.grossAmount; %>
+                        <% totalLabourCost += invoice.labourCost; %>
+                        <% totalMaterialCost += invoice.materialCost; %>
+                        <% totalCISAmount += invoice.cisAmount; %>
+                        <% totalNetAmount += invoice.netAmount; %>
+                        <% totalReverseCharge += invoice.reverseCharge; %>
+                        <% }); %>
+                        <tr>
+                            <td colspan="2"><strong>Total:</strong></td>
+                            <td></td>
+                            <td></td>
+                            <td><strong><%= formatCurrency(totalGross) %></strong></td>
+                            <td><strong><%= formatCurrency(totalLabourCost) %></strong></td>
+                            <td><strong><%= formatCurrency(totalMaterialCost) %></strong></td>
+                            <td><strong><%= formatCurrency(totalCISAmount) %></strong></td>
+                            <td><strong><%= formatCurrency(totalNetAmount) %></strong></td>
+                            <td></td>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <td><strong><%= formatCurrency(totalReverseCharge) %></strong></td>
+                            <% } %>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <! -- make another total table that takes from submission table, the inputted values and calculates the total of each column inside  -->
+                    </tbody>
+                </table>
+                <% } else { %>
+                <p class="text-muted text-center">
+                    No invoices available for the selected month and year.
+                </p>
+            <% } %>
+        </div>
+    <% }); %>
+</div>

--- a/mongoose/views/mongoose/monthlyReturnsForOneSubcontractor.ejs
+++ b/mongoose/views/mongoose/monthlyReturnsForOneSubcontractor.ejs
@@ -1,0 +1,143 @@
+<div class="text-center mt-4">
+    <h1 class="mb-4"><%= monthNames[month - 1] %> Monthly Returns</h1>
+    <%= subcontractor.name %> | <%= subcontractor.company %> @ <% if (subcontractor.deduction === 0.0) { %>
+        0%
+    <% } else if (subcontractor.deduction === 0.2) { %>
+        20%
+    <% } else if (subcontractor.deduction === 0.3) { %>
+        30%
+    <% } %>
+    <% if (subcontractor.isGross) { %>
+        GROSS
+    <% } %>
+    <br>
+    <%= subcontractor.utrNumber %> | <%= subcontractor.cisNumber %>
+    <address>
+        <%= subcontractor.line1 %>,
+        <%= subcontractor.line2 %>,
+        <%= subcontractor.city %>,
+        <%= subcontractor.county %>,
+        <%= subcontractor.postalCode %>
+    </address>
+</div>
+<div class="container">
+    <% const hasInvoices = invoices.length > 0; %>
+    <% if (hasInvoices) { %>
+        <table class="table table-hover table-sm caption-top">
+            <caption class="text-start">Month <%= month %></caption>
+            <thead>
+                <tr>
+                    <th>
+                        <span class="d-none d-md-table-cell">Invoice</span>
+                        <span class="d-md-none">Inv</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Kashflow</span>
+                        <span class="d-md-none">KF</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Invoiced</span>
+                        <span class="d-md-none">Invoiced</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Paid</span>
+                        <span class="d-md-none">Paid</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Gross</span>
+                        <span class="d-md-none">Gross</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Labour</span>
+                        <span class="d-md-none">Labour</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Material</span>
+                        <span class="d-md-none">Material</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">CIS @ <% if (subcontractor.deduction === 0.0) { %>
+                                0%
+                            <% } else if (subcontractor.deduction === 0.2) { %>
+                                20%
+                            <% } else if (subcontractor.deduction === 0.3) { %>
+                                30%
+                            <% } %>
+                        </span>
+                        <span class="d-md-none">CIS</span>
+                    </th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Net</span>
+                        <span class="d-md-none">Net</span>
+                    </th>
+                    <% if (subcontractor.isReverseCharge) { %>
+                        <th>
+                            <span class="d-none d-md-table-cell">Reverse Charge</span>
+                            <span class="d-md-none">RC</span>
+                        </th>
+                    <% } %>
+                    <th>Month</th>
+                    <th>Year</th>
+                    <th>
+                        <span class="d-none d-md-table-cell">Submission Date</span>
+                        <span class="d-md-none">Submission</span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="table-group-divider">
+                <% let totalGross = 0; %>
+                <% let totalLabourCost = 0; %>
+                <% let totalMaterialCost = 0; %>
+                <% let totalCISAmount = 0; %>
+                <% let totalNetAmount = 0; %>
+                <% let totalReverseCharge = 0; %>
+                <% invoices.forEach(invoice => { %>
+                <tr>
+                    <td><%= invoice.invoiceNumber %></td>
+                    <td><%= invoice.kashflowNumber %></td>
+                    <td><%= slimDateTime(invoice.invoiceDate) %></td>
+                    <td><%= slimDateTime(invoice.remittanceDate) %></td>
+                    <td><%= formatCurrency(invoice.grossAmount) %></td>
+                    <td><%= formatCurrency(invoice.labourCost) %></td>
+                    <td><%= formatCurrency(invoice.materialCost) %></td>
+                    <td><%= formatCurrency(invoice.cisAmount) %></td>
+                    <td><%= formatCurrency(invoice.netAmount) %></td>
+                    <% if (subcontractor.isReverseCharge) { %>
+                        <td><%= formatCurrency(invoice.reverseCharge) %></td>
+                    <% } %>
+                    <td><%= invoice.month %></td>
+                    <td><%= invoice.year %></td>
+                    <td><%= slimDateTime(invoice.submissionDate) %></td>
+                </tr>
+                <% totalGross += invoice.grossAmount; %>
+                <% totalLabourCost += invoice.labourCost; %>
+                <% totalMaterialCost += invoice.materialCost; %>
+                <% totalCISAmount += invoice.cisAmount; %>
+                <% totalNetAmount += invoice.netAmount; %>
+                <% totalReverseCharge += invoice.reverseCharge; %>
+                <% }); %>
+                <tr>
+                    <td colspan="2"><strong>Total:</strong></td>
+                    <td></td>
+                    <td></td>
+                    <td><strong><%= formatCurrency(totalGross) %></strong></td>
+                    <td><strong><%= formatCurrency(totalLabourCost) %></strong></td>
+                    <td><strong><%= formatCurrency(totalMaterialCost) %></strong></td>
+                    <td><strong><%= formatCurrency(totalCISAmount) %></strong></td>
+                    <td><strong><%= formatCurrency(totalNetAmount) %></strong></td>
+                    <td></td>
+                    <% if (subcontractor.isReverseCharge) { %>
+                        <td><strong><%= formatCurrency(totalReverseCharge) %></strong></td>
+                    <% } %>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+        <% } else { %>
+        <p class="text-muted text-center">
+            No invoices available for the selected month and year.
+        </p>
+    <% } %>
+</div>

--- a/mongoose/views/mongoose/monthlyReturnsForm.ejs
+++ b/mongoose/views/mongoose/monthlyReturnsForm.ejs
@@ -1,0 +1,48 @@
+<div class="container py-4">
+    <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+        <h1 class="display-5">Monthly Returns</h1>
+        <div class="accordion" id="subcontractorsAccordion">
+            <% subcontractorsWithMonths.forEach((data, index) => { %>
+                <% const subcontractor = data.subcontractor; %>
+                <% const years = data.years; %>
+                <% const invoicesByYear = data.invoicesByYear; %>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="heading-<%= subcontractor.id %>">
+                        <button class="accordion-button <%= index === 0 ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= subcontractor.id %>" aria-expanded="<%= index === 0 %>" aria-controls="collapse-<%= subcontractor.id %>">
+                            <%= subcontractor.dataValues.company %> <span class="badge bg-body-secondary ms-2"><%= years.length %> <%= years.length === 1 ? 'Year' : 'Years' %></span>
+                        </button>
+                    </h2>
+                    <div id="collapse-<%= subcontractor.id %>" class="accordion-collapse collapse <%= index === 0 ? 'show' : '' %>" aria-labelledby="heading-<%= subcontractor.id %>" data-bs-parent="#subcontractorsAccordion">
+                        <div class="accordion-body">
+                            <div class="row">
+                                <% years.forEach(year => { %>
+                                    <div class="col-md-6 col-lg-4 mb-3">
+                                        <div class="card h-100 bg-body-secondary p-2">
+                                            <h1 class="display-5"><%= year %></h5>
+                                            <div class="card-body text-center">
+                                                <ul class="list-group ">
+                                                    <li class="list-group-item">
+                                                        <a class="stretched-link" href="/yearly/returns/<%= year %>/<%= subcontractor.id %>">
+                                                            Yearly Report
+                                                        </a>
+                                                    </li>
+                                                    <% invoicesByYear[year].forEach(month => { %>
+                                                        <li class="list-group-item">
+                                                            <a class="stretched-link" href="/monthly/returns/<%= month %>/<%= year %>/<%= subcontractor.id %>">
+                                                                <%= monthNames[month - 1] %>
+                                                            </a>
+                                                        </li>
+                                                    <% }) %>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <% }); %>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <% }); %>
+        </div>
+    </div>
+</div>

--- a/mongoose/views/mongoose/monthlyReturnsYear.ejs
+++ b/mongoose/views/mongoose/monthlyReturnsYear.ejs
@@ -1,0 +1,141 @@
+<div class="text-center mt-4">
+    <h1 class="mb-4">Year <%= year %> Report</h1>
+    <% subcontractors.forEach(subcontractor => { %>
+        <div>
+            <%= subcontractor.name %> | <%= subcontractor.company %> @ <% if (subcontractor.deduction === 0.0) { %>
+                0%
+            <% } else if (subcontractor.deduction === 0.2) { %>
+                20%
+            <% } else if (subcontractor.deduction === 0.3) { %>
+                30%
+            <% } %>
+            <% if (subcontractor.isGross) { %>
+                GROSS
+            <% } %>
+            <br>
+            <%= subcontractor.utrNumber %> | <%= subcontractor.cisNumber %>
+        </div>
+        <div class="container">
+            <% const hasInvoices = subcontractor.invoices.length > 0; %>
+            <% if (hasInvoices) { %>
+                <table class="table table-hover table-sm caption-top">
+                    <caption class="text-start">Year <%= year %></caption>
+                    <thead>
+                        <tr>
+                            <th>
+                                <span class="d-none d-md-table-cell">Invoice</span>
+                                <span class="d-md-none">Inv</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Kashflow</span>
+                                <span class="d-md-none">KF</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Invoiced</span>
+                                <span class="d-md-none">Invoiced</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Paid</span>
+                                <span class="d-md-none">Paid</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Gross</span>
+                                <span class="d-md-none">Gross</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Labour</span>
+                                <span class="d-md-none">Labour</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Material</span>
+                                <span class="d-md-none">Material</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">CIS @ <% if (subcontractor.deduction === 0.0) { %>
+                                        0%
+                                    <% } else if (subcontractor.deduction === 0.2) { %>
+                                        20%
+                                    <% } else if (subcontractor.deduction === 0.3) { %>
+                                        30%
+                                    <% } %>
+                                </span>
+                                <span class="d-md-none">CIS</span>
+                            </th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Net</span>
+                                <span class="d-md-none">Net</span>
+                            </th>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <th>
+                                    <span class="d-none d-md-table-cell">Reverse Charge</span>
+                                    <span class="d-md-none">RC</span>
+                                </th>
+                            <% } %>
+                            <th>Month</th>
+                            <th>Year</th>
+                            <th>
+                                <span class="d-none d-md-table-cell">Submission Date</span>
+                                <span class="d-md-none">Submission</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="table-group-divider">
+                        <% let totalGross = 0; %>
+                        <% let totalLabourCost = 0; %>
+                        <% let totalMaterialCost = 0; %>
+                        <% let totalCISAmount = 0; %>
+                        <% let totalNetAmount = 0; %>
+                        <% let totalReverseCharge = 0; %>
+                        <% subcontractor.invoices.forEach(invoice => { %>
+                        <tr>
+                            <td><%= invoice.invoiceNumber %></td>
+                            <td><%= invoice.kashflowNumber %></td>
+                            <td><%= slimDateTime(invoice.invoiceDate) %></td>
+                            <td><%= slimDateTime(invoice.remittanceDate) %></td>
+                            <td><%= formatCurrency(invoice.grossAmount) %></td>
+                            <td><%= formatCurrency(invoice.labourCost) %></td>
+                            <td><%= formatCurrency(invoice.materialCost) %></td>
+                            <td><%= formatCurrency(invoice.cisAmount) %></td>
+                            <td><%= formatCurrency(invoice.netAmount) %></td>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <td><%= formatCurrency(invoice.reverseCharge) %></td>
+                            <% } %>
+                            <td><%= invoice.month %></td>
+                            <td><%= invoice.year %></td>
+                            <td><%= slimDateTime(invoice.submissionDate) %></td>
+                        </tr>
+                        <% totalGross += invoice.grossAmount; %>
+                        <% totalLabourCost += invoice.labourCost; %>
+                        <% totalMaterialCost += invoice.materialCost; %>
+                        <% totalCISAmount += invoice.cisAmount; %>
+                        <% totalNetAmount += invoice.netAmount; %>
+                        <% totalReverseCharge += invoice.reverseCharge; %>
+                        <% }); %>
+                        <tr>
+                            <td colspan="2"><strong>Total:</strong></td>
+                            <td></td>
+                            <td></td>
+                            <td><strong><%= formatCurrency(totalGross) %></strong></td>
+                            <td><strong><%= formatCurrency(totalLabourCost) %></strong></td>
+                            <td><strong><%= formatCurrency(totalMaterialCost) %></strong></td>
+                            <td><strong><%= formatCurrency(totalCISAmount) %></strong></td>
+                            <td><strong><%= formatCurrency(totalNetAmount) %></strong></td>
+                            <td></td>
+                            <% if (subcontractor.isReverseCharge) { %>
+                                <td><strong><%= formatCurrency(totalReverseCharge) %></strong></td>
+                            <% } %>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <! -- make another total table that takes from submission table, the inputted values and calculates the total of each column inside  -->
+                    </tbody>
+                </table>
+                <% } else { %>
+                <p class="text-muted text-center">
+                    No invoices available for the selected month and year.
+                </p>
+            <% } %>
+        </div>
+    <% }); %>
+</div>

--- a/mongoose/views/mongoose/weeklyAttendance.ejs
+++ b/mongoose/views/mongoose/weeklyAttendance.ejs
@@ -1,0 +1,89 @@
+<div class="container py-4">
+    <div class="mb-4 bg-body-tertiary rounded-3">
+
+        <!-- Navigation Tabs -->
+        <ul class="nav nav-tabs justify-content-center mb-4">
+            <li class="nav-item">
+                <a href="/attendance/daily" class="nav-link <%= currentTab === 'daily' ? 'active' : '' %>">Daily</a>
+            </li>
+            <li class="nav-item">
+                <a href="/attendance/weekly" class="nav-link <%= currentTab === 'weekly' ? 'active' : '' %>">Weekly</a>
+            </li>
+        </ul>
+
+        <!-- Week Navigation -->
+        <div class="d-flex justify-content-between mb-4 d-print-none">
+            <button class="btn btn-hcs-green">
+                <a class="text-white text-decoration-none" href="/attendance/weekly/<%= previousYear %>/<%= previousWeek %>">&laquo; Previous Week</a>
+            </button>
+            <h1 class="display-5 text-center">Weekly Attendance</h1>
+            <button class="btn btn-hcs-green">
+                <a class="text-white text-decoration-none" href="/attendance/weekly/<%= nextYear %>/<%= nextWeek %>">Next Week &raquo;</a>
+            </button>
+        </div>
+
+        <p class="text-center">From <%= moment(startDate).format('Do MMMM YYYY') %> to <%= moment(endDate).format('Do MMMM YYYY') %></p>
+
+        <!-- Weekly Totals -->
+        <div class="row mb-4">
+            <div class="col-lg-6 col-md-6">
+                <div class="card text-center">
+                    <div class="card-body">
+                        <h4>Total Employee Payment</h4>
+                        <p class="display-6">£<%= totalEmployeePay.toFixed(2) %> <small class="fs-6">gross</small></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6 col-md-6">
+                <div class="card text-center">
+                    <div class="card-body">
+                        <h4>Total Subcontractor Payment</h4>
+                        <p class="display-6">£<%= totalSubcontractorPay.toFixed(2) %> <small class="fs-6">net</small></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Total Employee Hours -->
+        <div class="row mb-4">
+            <div class="col-lg-6 col-md-6">
+                <div class="card text-center">
+                    <div class="card-body">
+                        <h4>Total Employee Hours Worked</h4>
+                        <p class="display-6"><%= totalEmployeeHours ? totalEmployeeHours : '0' %> hours</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <% 
+            const employeeEntries = Object.entries(groupedAttendance).filter(([_, v]) => v.type === 'employee');
+            const subcontractorEntries = Object.entries(groupedAttendance).filter(([_, v]) => v.type === 'subcontractor');
+        %>
+
+        <!-- Employee Table -->
+        <h3 class="mt-5 mb-3">Employees</h3>
+        <div class="table-responsive mb-5">
+            <%- include('./partials/weeklyTable', {
+                entries: employeeEntries,
+                daysOfWeek,
+                startDate,
+                endDate,
+                moment
+            }) %>
+        </div>
+
+        <!-- Subcontractor Table -->
+        <h3 class="mt-5 mb-3">Subcontractors</h3>
+        <div class="table-responsive mb-5">
+            <%- include('./partials/weeklyTable', {
+                entries: subcontractorEntries,
+                daysOfWeek,
+                startDate,
+                endDate,
+                moment
+            }) %>
+        </div>
+
+    </div>
+</div>

--- a/mongoose/views/mongoose/yearlyReturns.ejs
+++ b/mongoose/views/mongoose/yearlyReturns.ejs
@@ -1,0 +1,351 @@
+<div class="page-number">
+    <%= subcontractor.company %> | Heron Constructive Solutions LTD | <%= year %> Yearly Returns
+</div>
+<div class="mt-4">
+    <h1 class="mb-4 display-3 text-center">
+        <%= year %> Yearly Returns
+    </h1>
+    <div class="row justify-content-evenly">
+        <div class="col-6 ms-auto text-center">
+            <p class="display-5">
+                Subcontractor
+            </p>
+            <%= subcontractor.company %>
+                <% if (subcontractor.utrNumber) { %>
+                    <br>
+                    UTR: <%= subcontractor.utrNumber %>
+                        <% } %>
+                            <% if (subcontractor.vatNumber) { %>
+                                <br>
+                                VAT: <%= subcontractor.vatNumber %>
+                                    <% } %>
+                                        <% if (subcontractor.cisNumber) { %>
+                                            <br>
+                                            CIS: <%= subcontractor.cisNumber %>
+                                                <% } %>
+                                                    <br>
+                                                    <address>
+                                                        <%= subcontractor.line1 %>,
+                                                            <%= subcontractor.line2 %>,
+                                                                <%= subcontractor.city %>,
+                                                                    <%= subcontractor.county %>,
+                                                                        <%= subcontractor.postalCode %>.
+                                                    </address>
+        </div>
+        <div class="col-6 text-center">
+            <p class="display-5">
+                Contractor
+            </p>
+            Heron Constructive Solutions LTD
+            <br>
+            Company: 09276951
+            <br>
+            VAT: 252295994
+            <br>
+            <address>
+                103 Herondale Road,
+                Mossley Hill,
+                Liverpool,
+                Merseyside,
+                L18 1JZ.
+        </div>
+    </div>
+</div>
+<% for (let monthIndex=1; monthIndex <=12; monthIndex++) { %>
+    <% const monthKey=monthIndex.toString(); %>
+        <% const invoices=invoicesByMonth[monthKey] || []; %>
+            <% const hasInvoices=invoices.length> 0; %>
+                <% if (hasInvoices) { %>
+                    <% if (pageBreakMonths.includes(monthIndex)) { %>
+                        <table class="table table-hover table-sm caption-top page-break d-print-table">
+                            <% } else { %>
+                                <table class="table table-hover table-sm caption-top d-print-table">
+                                    <% } %>
+                                        <caption class="text-center">Month <%= monthKey %> (<%= monthNames[monthIndex -
+                                                    1] %>
+                                                    <%= year %>)</caption>
+                                        <thead>
+                                            <tr>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Invoice</span>
+                                                    <span class="d-md-none">Inv</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Kashflow</span>
+                                                    <span class="d-md-none">KF</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Invoiced</span>
+                                                    <span class="d-md-none">Invoiced</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Paid</span>
+                                                    <span class="d-md-none">Paid</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Gross</span>
+                                                    <span class="d-md-none">Gross</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Labour</span>
+                                                    <span class="d-md-none">Labour</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Material</span>
+                                                    <span class="d-md-none">Material</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">CIS @ <% if
+                                                            (subcontractor.deduction===0.0) { %>
+                                                            0%
+                                                            <% } else if (subcontractor.deduction===0.2) { %>
+                                                                20%
+                                                                <% } else if (subcontractor.deduction===0.3) { %>
+                                                                    30%
+                                                                    <% } %></span>
+                                                    <span class="d-md-none">CIS</span>
+                                                </th>
+                                                <th>
+                                                    <span class="d-none d-md-table-cell">Net</span>
+                                                    <span class="d-md-none">Net</span>
+                                                </th>
+                                                <% if (subcontractor.isReverseCharge) { %>
+                                                    <th>
+                                                        <span class="d-none d-md-table-cell">Reverse Charge</span>
+                                                        <span class="d-md-none">RC</span>
+                                                    </th>
+                                                    <% } %>
+                                                        <th>
+                                                            <span class="d-none d-md-table-cell">Submission Date</span>
+                                                            <span class="d-md-none">Submission</span>
+                                                        </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody class="table-group-divider">
+                                            <% let totalGross=0; %>
+                                                <% let totalLabourCost=0; %>
+                                                    <% let totalMaterialCost=0; %>
+                                                        <% let totalCISAmount=0; %>
+                                                            <% let totalNetAmount=0; %>
+                                                                <% let totalReverseCharge=0; %>
+                                                                    <% invoices.forEach(invoice=> { %>
+                                                                        <tr class="d-print-table-row">
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= invoice.invoiceNumber %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= invoice.kashflowNumber %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= slimDateTime(invoice.invoiceDate) %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= slimDateTime(invoice.remittanceDate)
+                                                                                    %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= formatCurrency(invoice.grossAmount)
+                                                                                    %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= formatCurrency(invoice.labourCost)
+                                                                                    %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= formatCurrency(invoice.materialCost)
+                                                                                    %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= formatCurrency(invoice.cisAmount) %>
+                                                                            </td>
+                                                                            <td class="d-print-table-cell">
+                                                                                <%= formatCurrency(invoice.netAmount) %>
+                                                                            </td>
+                                                                            <% if (subcontractor.isReverseCharge) { %>
+                                                                                <td class="d-print-table-cell">
+                                                                                    <%= formatCurrency(invoice.reverseCharge)
+                                                                                        %>
+                                                                                </td>
+                                                                                <% } %>
+                                                                                    <td class="d-print-table-cell">
+                                                                                        <%= slimDateTime(invoice.submissionDate)
+                                                                                            %>
+                                                                                    </td>
+                                                                        </tr>
+                                                                        <% totalGross +=invoice.grossAmount; %>
+                                                                            <% totalLabourCost +=invoice.labourCost; %>
+                                                                                <% totalMaterialCost
+                                                                                    +=invoice.materialCost; %>
+                                                                                    <% totalCISAmount
+                                                                                        +=invoice.cisAmount; %>
+                                                                                        <% totalNetAmount
+                                                                                            +=invoice.netAmount; %>
+                                                                                            <% totalReverseCharge
+                                                                                                +=invoice.reverseCharge;
+                                                                                                %>
+                                                                                                <% }); %>
+
+                                                                                                    <tr
+                                                                                                        class="d-print-table-row">
+                                                                                                        <!-- Display the totals for the invoices in this month -->
+                                                                                                        <td class="d-print-table-cell"
+                                                                                                            colspan="2">
+                                                                                                            <strong>Month
+                                                                                                                <%= monthKey
+                                                                                                                    %>
+                                                                                                                    :
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalGross)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalLabourCost)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalMaterialCost)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalCISAmount)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalNetAmount)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <% if
+                                                                                                            (subcontractor.isReverseCharge)
+                                                                                                            { %>
+                                                                                                            <td
+                                                                                                                class="d-print-table-cell">
+                                                                                                                <strong>
+                                                                                                                    <%= formatCurrency(totalReverseCharge)
+                                                                                                                        %>
+                                                                                                                </strong>
+                                                                                                            </td>
+                                                                                                            <% } %>
+                                                                                                                <td
+                                                                                                                    class="d-print-table-cell">
+                                                                                                                </td>
+                                                                                                    </tr>
+                                                                                                    <tr
+                                                                                                        class="d-print-table-row">
+                                                                                                        <!-- Display the totals for the invoices in this month -->
+                                                                                                        <td class="d-print-table-cell"
+                                                                                                            colspan="2">
+                                                                                                            <strong>Submission:</strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(rounding(totalGross,false))
+                                                                                                                    %>
+                                                                                                            </strong>
+
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(rounding(totalLabourCost,false))
+                                                                                                                    %>
+                                                                                                            </strong>
+
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(rounding(totalMaterialCost,false))
+                                                                                                                    %>
+                                                                                                            </strong>
+
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalCISAmount)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <td
+                                                                                                            class="d-print-table-cell">
+                                                                                                            <strong>
+                                                                                                                <%= formatCurrency(totalNetAmount)
+                                                                                                                    %>
+                                                                                                            </strong>
+                                                                                                        </td>
+                                                                                                        <% if
+                                                                                                            (subcontractor.isReverseCharge)
+                                                                                                            { %>
+                                                                                                            <td
+                                                                                                                class="d-print-table-cell">
+                                                                                                                <strong>
+                                                                                                                    <%= formatCurrency(totalReverseCharge)
+                                                                                                                        %>
+                                                                                                                </strong>
+                                                                                                            </td>
+                                                                                                            <% } %>
+                                                                                                                <td
+                                                                                                                    class="d-print-table-cell">
+                                                                                                                </td>
+                                                                                                    </tr>
+                                        </tbody>
+                                </table>
+                                <% } else { %>
+                                    <% } %>
+                                        <% } %>
+                                            <style>
+                                                @media print {
+                                                    @page {
+                                                        @top-right {
+                                                            content: counter(page);
+                                                        }
+                                                    }
+
+                                                    body {
+                                                        padding: 50px;
+                                                        /* Adjust as needed */
+                                                    }
+
+                                                    .page-number {
+                                                        position: fixed;
+                                                        bottom: 10px;
+                                                        /* Adjust as needed */
+                                                        right: 10px;
+                                                        /* Adjust as needed */
+                                                    }
+
+                                                    .page-break {
+                                                        page-break-before: always;
+                                                    }
+                                                }
+                                            </style>


### PR DESCRIPTION
## Summary
- implement mongoose Monthly and Yearly Returns controllers and routes
- add attendance daily/weekly controllers and CRUD controllers using mongoose
- create corresponding routes
- provide EJS views for new mongoose pages

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517c8e1f1c832a96d3fb4b02ca980e