### PR TITLE
Implement YAML-based permissions

### DIFF
--- a/models/mongoose/user.js
+++ b/models/mongoose/user.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
 const encryptionService = require('../../services/encryptionService');
+const { getPermissionsForRole } = require('../../services/permissionsService');
 const { v4: uuidv4 } = require('uuid');
 const { Schema } = mongoose;
 
@@ -66,6 +67,11 @@ const userSchema = new Schema({
 userSchema.pre('save', async function (next) {
     if (this.isModified('password')) {
         this.password = await bcrypt.hash(this.password, 10);
+    }
+
+    // Assign permissions if new or role changed or permissions empty
+    if (this.isNew || this.isModified('role') || !this.permissions || Object.keys(this.permissions).length === 0) {
+        this.permissions = getPermissionsForRole(this.role);
     }
 
     // Ensure only one of the foreign keys is set

--- a/mongoose/controllers/registerController.js
+++ b/mongoose/controllers/registerController.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const path = require('path');
 const logger = require('../../services/loggerService');
 const mdb = require('../../services/mongoose/mongooseDatabaseService');
+const { getPermissionsForRole } = require('../../services/permissionsService');
 
 exports.renderRegistrationForm = (req, res, next) => {
     res.render(path.join('mongoose', 'register'), {
@@ -47,11 +48,13 @@ exports.registerUser = async (req, res, next) => {
             return res.redirect('/user/register');
         }
 
+        const assignedRole = role || 'subcontractor';
         const newUser = new mdb.user({
             username,
             email,
             password,
-            role: role || 'subcontractor'
+            role: assignedRole,
+            permissions: getPermissionsForRole(assignedRole)
         });
 
         await newUser.save();

--- a/mongoose/routes/attendanceCrud.js
+++ b/mongoose/routes/attendanceCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/attendanceCRUDController');
 
-router.post('/attendance/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createAttendance);
-router.get('/attendance/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readAttendance);
-router.post('/attendance/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateAttendance);
-router.post('/attendance/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteAttendance);
+router.post('/attendance/create', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.createAttendance);
+router.get('/attendance/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.readAttendance);
+router.post('/attendance/update/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.updateAttendance);
+router.post('/attendance/delete/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.deleteAttendance);
 
 module.exports = router;

--- a/mongoose/routes/cis.js
+++ b/mongoose/routes/cis.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const cis = require('../controllers/cisController');
 
-router.get('/mdb/CIS/:year/:month', auth.ensureAuthenticated, auth.ensureRole('admin'), cis.renderCISDashboardMongo);
-router.get('/mdb/CIS', auth.ensureAuthenticated, auth.ensureRole('admin'), cis.redirectCIS);
+router.get('/mdb/CIS/:year/:month', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), cis.renderCISDashboardMongo);
+router.get('/mdb/CIS', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), cis.redirectCIS);
 
 module.exports = router;

--- a/mongoose/routes/customers.js
+++ b/mongoose/routes/customers.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const customers = require('../controllers/customersController');
 
-router.get('/customers', auth.ensureAuthenticated, auth.ensureRole('admin'), customers.listCustomers);
-router.get('/customer/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), customers.viewCustomer);
+router.get('/customers', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), customers.listCustomers);
+router.get('/customer/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), customers.viewCustomer);
 
 module.exports = router;

--- a/mongoose/routes/dailyAttendance.js
+++ b/mongoose/routes/dailyAttendance.js
@@ -3,6 +3,6 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/dailyAttendanceController');
 
-router.get('/attendance/daily/:date?', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.getDailyAttendance);
+router.get('/attendance/daily/:date?', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.getDailyAttendance);
 
 module.exports = router;

--- a/mongoose/routes/employeeCrud.js
+++ b/mongoose/routes/employeeCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/employeeCRUDController');
 
-router.post('/employee/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createEmployee);
-router.get('/employee/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readEmployee);
-router.post('/employee/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateEmployee);
-router.post('/employee/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteEmployee);
+router.post('/employee/create', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.createEmployee);
+router.get('/employee/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.readEmployee);
+router.post('/employee/update/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.updateEmployee);
+router.post('/employee/delete/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.deleteEmployee);
 
 module.exports = router;

--- a/mongoose/routes/invoices.js
+++ b/mongoose/routes/invoices.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const invoices = require('../controllers/invoicesController');
 
-router.get('/invoices', auth.ensureAuthenticated, auth.ensureRole('admin'), invoices.listInvoices);
-router.get('/invoice/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), invoices.viewInvoice);
+router.get('/invoices', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), invoices.listInvoices);
+router.get('/invoice/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), invoices.viewInvoice);
 
 module.exports = router;

--- a/mongoose/routes/locationCrud.js
+++ b/mongoose/routes/locationCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/locationCRUDController');
 
-router.post('/location/create', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.createLocation);
-router.get('/location/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.readLocation);
-router.post('/location/update/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.updateLocation);
-router.post('/location/delete/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.deleteLocation);
+router.post('/location/create', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.createLocation);
+router.get('/location/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.readLocation);
+router.post('/location/update/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.updateLocation);
+router.post('/location/delete/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.deleteLocation);
 
 module.exports = router;

--- a/mongoose/routes/monthlyReturns.js
+++ b/mongoose/routes/monthlyReturns.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/monthlyReturnsController');
 
-router.get('/monthly/returns/form', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderMonthlyReturnsForm);
-router.get('/monthly/returns/:month/:year/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderMonthlyReturns);
+router.get('/monthly/returns/form', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.renderMonthlyReturnsForm);
+router.get('/monthly/returns/:month/:year/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.renderMonthlyReturns);
 
 module.exports = router;

--- a/mongoose/routes/quotes.js
+++ b/mongoose/routes/quotes.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const quotes = require('../controllers/quotesController');
 
-router.get('/quotes', auth.ensureAuthenticated, auth.ensureRole('admin'), quotes.listQuotes);
-router.get('/quote/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), quotes.viewQuote);
+router.get('/quotes', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), quotes.listQuotes);
+router.get('/quote/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), quotes.viewQuote);
 
 module.exports = router;

--- a/mongoose/routes/receipts.js
+++ b/mongoose/routes/receipts.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const receipts = require('../controllers/receiptsListController');
 
-router.get('/receipts', auth.ensureAuthenticated, auth.ensureRole('admin'), receipts.listReceipts);
-router.get('/receipt/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), receipts.viewReceipt);
+router.get('/receipts', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), receipts.listReceipts);
+router.get('/receipt/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), receipts.viewReceipt);
 
 module.exports = router;

--- a/mongoose/routes/suppliers.js
+++ b/mongoose/routes/suppliers.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const suppliers = require('../controllers/suppliersController');
 
-router.get('/suppliers', auth.ensureAuthenticated, auth.ensureRole('admin'), suppliers.listSuppliers);
-router.get('/supplier/read/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), suppliers.viewSupplier);
+router.get('/suppliers', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), suppliers.listSuppliers);
+router.get('/supplier/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), suppliers.viewSupplier);
 
 module.exports = router;

--- a/mongoose/routes/weeklyAttendance.js
+++ b/mongoose/routes/weeklyAttendance.js
@@ -3,10 +3,10 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/weeklyAttendanceController');
 
-router.get('/attendance/weekly', auth.ensureAuthenticated, auth.ensureRole('admin'), (req,res,next)=>{
+router.get('/attendance/weekly', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), (req,res,next)=>{
   const currentYear = require('../../services/taxService').getCurrentTaxYear();
   res.redirect(`/attendance/weekly/${currentYear}`);
 });
-router.get('/attendance/weekly/:year?/:week?', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.getWeeklyAttendance);
+router.get('/attendance/weekly/:year?/:week?', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.getWeeklyAttendance);
 
 module.exports = router;

--- a/mongoose/routes/yearlyReturns.js
+++ b/mongoose/routes/yearlyReturns.js
@@ -3,6 +3,6 @@ const router = express.Router();
 const auth = require('../../services/mongoose/authServiceMongoose');
 const ctrl = require('../controllers/yearlyReturnsController');
 
-router.get('/yearly/returns/:year/:uuid', auth.ensureAuthenticated, auth.ensureRole('admin'), ctrl.renderYearlyReturns);
+router.get('/yearly/returns/:year/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), ctrl.renderYearlyReturns);
 
 module.exports = router;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express-useragent": "^1.0.15",
     "express-validator": "^7.2.0",
     "helmet": "^7.0.0",
+    "js-yaml": "^4.1.0",
     "joi": "^17.11.0",
     "json2csv": "^6.0.0-alpha.2",
     "mariadb": "^3.4.2",

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -1,0 +1,28 @@
+admin:
+  createUser: true
+  readUser: true
+  updateUser: true
+  deleteUser: true
+  createInvoice: true
+  readInvoice: true
+  updateInvoice: true
+  deleteInvoice: true
+  createSubcontractor: true
+  readSubcontractor: true
+  updateSubcontractor: true
+  deleteSubcontractor: true
+  unpaidInvoices: true
+  unsubmittedInvoices: true
+  adminAccess: true
+subcontractor:
+  readInvoice: true
+  createInvoice: true
+employee:
+  readUser: true
+accountant:
+  readInvoice: true
+  updateInvoice: true
+hmrc:
+  readInvoice: true
+client:
+  readInvoice: true

--- a/services/permissionsService.js
+++ b/services/permissionsService.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const filePath = path.join(__dirname, '..', 'permissions.yaml');
+let rolePermissions = {};
+
+function loadPermissions() {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    rolePermissions = yaml.load(data) || {};
+  } catch (err) {
+    rolePermissions = {};
+  }
+}
+
+function getPermissionsForRole(role) {
+  if (!Object.keys(rolePermissions).length) loadPermissions();
+  return rolePermissions[role] || {};
+}
+
+function getAllPermissions() {
+  if (!Object.keys(rolePermissions).length) loadPermissions();
+  return rolePermissions;
+}
+
+loadPermissions();
+module.exports = { getPermissionsForRole, getAllPermissions, loadPermissions };


### PR DESCRIPTION
## Summary
- add YAML list of default permissions
- load permissions via permissionsService
- assign role permissions when creating mongoose users
- enforce `adminAccess` permission on mongoose routes
- include js-yaml dependency

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851909832a8832ab6dd75d59332d112