### PR TITLE
Add placeholder EJS pages

### DIFF
--- a/views/render/construction-industry-scheme.ejs
+++ b/views/render/construction-industry-scheme.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>

--- a/views/render/create.ejs
+++ b/views/render/create.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>

--- a/views/render/human-resources.ejs
+++ b/views/render/human-resources.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>

--- a/views/render/kashflow.ejs
+++ b/views/render/kashflow.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>

--- a/views/render/management.ejs
+++ b/views/render/management.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>

--- a/views/render/payroll.ejs
+++ b/views/render/payroll.ejs
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3 text-center">
+    <h1 class="display-5 fw-bold"><%= typeof title !== 'undefined' ? title : '' %></h1>
+    <p class="fs-5 text-body-secondary">This page is under construction.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add placeholder pages for construction industry scheme, management, payroll, human resources, kashflow and create routes

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851935838dc832a8fc6022a6d12b2b2