### PR TITLE
Implement Mongoose receipt update route

### DIFF
--- a/mongoose/controllers/receiptsListController.js
+++ b/mongoose/controllers/receiptsListController.js
@@ -62,3 +62,25 @@ exports.viewReceipt = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.changeReceipts = async (req, res, next) => {
+  try {
+    const { submissionDate, uuids, redirectPath } = req.body;
+    const targetUUIDs = uuids && uuids.length ? (Array.isArray(uuids) ? uuids : [uuids]) : [];
+
+    if (targetUUIDs.length === 0) {
+      req.flash('error', 'No receipts selected.');
+      return res.redirect(redirectPath || '/mdb/CIS');
+    }
+
+    await mdb.receipt.updateMany(
+      { uuid: { $in: targetUUIDs } },
+      { $set: { SubmissionDate: submissionDate ? new Date(submissionDate) : null } }
+    );
+
+    res.redirect(redirectPath || '/mdb/CIS');
+  } catch (error) {
+    next(error);
+  }
+};
+

--- a/mongoose/routes/receipts.js
+++ b/mongoose/routes/receipts.js
@@ -5,5 +5,6 @@ const receipts = require('../controllers/receiptsListController');
 
 router.get('/receipts', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), receipts.listReceipts);
 router.get('/receipt/read/:uuid', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), receipts.viewReceipt);
+router.post('/receipt/change', auth.ensureAuthenticated, auth.ensurePermission(['adminAccess']), receipts.changeReceipts);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add `changeReceipts` handler to update SubmissionDate on receipts
- expose POST `/receipt/change` endpoint in mongoose router

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685193dcbd58832a88de985c1a387a5d