### PR TITLE
Switch from JWT auth to express-session

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const packageJson = require('./package.json');
 const crypto = require('crypto');
 
 const mdb = require('./services/mongoose/mongooseDatabaseService');
+const sessionService = require('./services/mongoose/sessionServiceMongoose');
 const { ensureAuthenticated } = require('./services/authService');
 
 const main = async () => {
@@ -30,8 +31,9 @@ const main = async () => {
     app.use(express.json());
     app.use(express.urlencoded({ extended: true }));
 
-    // Add cookie parser for JWT and pending2FA
+    // Cookie parser and session handling
     app.use(cookieParser());
+    app.use(sessionService);
 
     // Static assets
     app.use('/resources', express.static(path.join(__dirname, 'public')));

--- a/mongoose/controllers/loginController.js
+++ b/mongoose/controllers/loginController.js
@@ -1,10 +1,8 @@
 const axios = require('axios');
 const bcrypt = require('bcrypt');
 const path = require('path');
-const jwt = require('jsonwebtoken');
 const logger = require('../../services/loggerService');
 const mdb = require('../../services/mongoose/mongooseDatabaseService');
-const generateToken = require('../../services/generateTokenService');
 
 exports.renderLoginForm = (req, res) => {
   res.render(path.join('mongoose', 'login'), {
@@ -53,8 +51,9 @@ exports.loginUser = async (req, res) => {
       return res.redirect('/user/login');
     }
 
-    const payload = {
-      userId: user._id.toString(),
+    const sessionData = {
+      id: user._id.toString(),
+      uuid: user.uuid,
       username: user.username,
       email: user.email,
       role: user.role,
@@ -71,22 +70,14 @@ exports.loginUser = async (req, res) => {
 
     // If TOTP is enabled, stage login for /user/2fa
     if (user.totpEnabled) {
-      const pendingToken = generateToken(payload, '5m');
-      res.cookie('pending2FA', pendingToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'Strict',
-        maxAge: 1000 * 60 * 5
-      });
+      req.session.userPending2FA = sessionData;
       return res.redirect('/user/2fa');
     }
 
-    const authToken = generateToken(payload, '8h');
-    res.cookie('token', authToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'Strict',
-      maxAge: 1000 * 60 * 60 * 8
+    req.session.user = sessionData;
+
+    await new Promise((resolve, reject) => {
+      req.session.save(err => (err ? reject(err) : resolve()));
     });
 
     logger.info(`${user.username} successfully logged in.`);
@@ -101,8 +92,14 @@ exports.loginUser = async (req, res) => {
 };
 
 exports.logoutUser = (req, res) => {
-  res.clearCookie('token');
-  res.clearCookie('pending2FA');
-  req.flash('success', 'You have been logged out.');
-  return res.redirect('/user/login');
+  req.session.destroy(err => {
+    if (err) {
+      logger.error('Error logging out: ' + err.message);
+      req.flash('error', 'An error occurred while logging out.');
+      return res.redirect('/');
+    }
+    res.clearCookie('connect.sid');
+    req.flash('success', 'You have been logged out.');
+    return res.redirect('/user/login');
+  });
 };

--- a/mongoose/controllers/twoFAController.js
+++ b/mongoose/controllers/twoFAController.js
@@ -1,41 +1,29 @@
 const path = require('path');
 const speakeasy = require('speakeasy');
-const jwt = require('jsonwebtoken');
 const logger = require('../../services/loggerService');
 const mdb = require('../../services/mongoose/mongooseDatabaseService');
 const encryptionService = require('../../services/encryptionService');
-const generateToken = require('../../services/generateTokenService');
 
 exports.render2FAPage = (req, res) => {
-  const pendingToken = req.cookies.pending2FA;
-
-  if (!pendingToken) {
+  if (!req.session.userPending2FA) {
     req.flash('error', '2FA session expired. Please log in again.');
     return res.redirect('/user/login');
   }
 
-  try {
-    const decoded = jwt.verify(pendingToken, process.env.JWT_SECRET);
-    res.render(path.join('user', '2fa'), { title: 'Two-Factor Authentication' });
-  } catch (err) {
-    res.clearCookie('pending2FA');
-    req.flash('error', '2FA token invalid or expired.');
-    return res.redirect('/user/login');
-  }
+  res.render(path.join('user', '2fa'), { title: 'Two-Factor Authentication' });
 };
 
 exports.verify2FA = async (req, res) => {
   try {
     const code = req.body.totpToken;
-    const pendingToken = req.cookies.pending2FA;
+    const pending = req.session.userPending2FA;
 
-    if (!pendingToken) {
+    if (!pending) {
       req.flash('error', '2FA session missing. Please log in again.');
       return res.redirect('/user/login');
     }
 
-    const decoded = jwt.verify(pendingToken, process.env.JWT_SECRET);
-    const user = await mdb.user.findOne({ uuid: decoded.uuid });
+    const user = await mdb.user.findOne({ uuid: pending.uuid });
 
     if (!user || !user.totpSecret) {
       req.flash('error', 'User not found or 2FA not enabled.');
@@ -59,8 +47,9 @@ exports.verify2FA = async (req, res) => {
     const agent = req.useragent || {};
     const ip = req.ip;
 
-    const authToken = generateToken({
-      userId: user._id.toString(),
+    req.session.user = {
+      id: user._id.toString(),
+      uuid: user.uuid,
       username: user.username,
       email: user.email,
       role: user.role,
@@ -73,22 +62,19 @@ exports.verify2FA = async (req, res) => {
         os: agent.os || 'Unknown',
         platform: agent.platform || 'Unknown',
       },
-    }, '8h');
+    };
 
-    res.clearCookie('pending2FA');
+    delete req.session.userPending2FA;
 
-    res.cookie('token', authToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'Strict',
-      maxAge: 1000 * 60 * 60 * 8
+    await new Promise((resolve, reject) => {
+      req.session.save(err => (err ? reject(err) : resolve()));
     });
 
     req.flash('success', 'Successfully logged in.');
     return res.redirect('/');
   } catch (error) {
     logger.error('2FA verification error: ' + error.message);
-    res.clearCookie('pending2FA');
+    delete req.session.userPending2FA;
     req.flash('error', 'An error occurred during 2FA. Please log in again.');
     return res.redirect('/user/login');
   }

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,22 +1,18 @@
-const jwt = require('jsonwebtoken');
 const mdb = require('./mongoose/mongooseDatabaseService');
 
-// Checks token and populates req.user (non-blocking)
+// Populate req.user from session if available (non-blocking)
 async function ensureAuthenticated(req, res, next) {
-  const token = req.cookies.token;
-
-  if (!token) return next();
+  if (!req.session || !req.session.user) return next();
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const user = await mdb.user.findById(decoded.id);
+    const user = await mdb.user.findById(req.session.user.id);
     if (user) {
       req.user = user;
     } else {
-      res.clearCookie('token');
+      delete req.session.user;
     }
   } catch (err) {
-    res.clearCookie('token');
+    delete req.session.user;
   }
 
   next();
@@ -25,7 +21,7 @@ async function ensureAuthenticated(req, res, next) {
 // Blocks if user is not authenticated
 function requireLogin(req, res, next) {
   if (!req.user) {
-    return res.redirect('/signin'); // or res.status(401).send('Unauthorized');
+    return res.redirect('/user/login');
   }
   next();
 }
@@ -33,7 +29,7 @@ function requireLogin(req, res, next) {
 // Blocks if user is authenticated (e.g. signin/register pages)
 function doesntRequireLogin(req, res, next) {
   if (req.user) {
-    return res.redirect('/dashboard'); // or wherever you want to redirect logged-in users
+    return res.redirect('/');
   }
   next();
 }


### PR DESCRIPTION
## Summary
- rely on connect-mongo session middleware
- update auth service to pull user info from the session
- rewrite login and 2FA controllers to use express-session

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523d685368832ab155afce0e367c72