### PR TITLE
Implement default admin role guard

### DIFF
--- a/controllers/CRUD/attendanceCRUD.js
+++ b/controllers/CRUD/attendanceCRUD.js
@@ -162,7 +162,7 @@ const deleteAttendance = async (req, res, next) => {
     }
 };
 
-router.get('/fetch/attendance/:id',  authService.ensureRoles('admin'), async (req, res, next) => {
+router.get('/fetch/attendance/:id',  authService.ensureRole(), async (req, res, next) => {
     try {
         const attendance = await db.Attendances.findOne({
             where: { id: req.params.id },
@@ -184,9 +184,9 @@ router.get('/fetch/attendance/:id',  authService.ensureRoles('admin'), async (re
 });
 
 
-router.post('/create',  authService.ensureRoles('admin'), createAttendance);
-router.get('/read/:attendance',  authService.ensureRoles('admin'), readAttendance);
-router.post('/update/:attendance',  authService.ensureRoles('admin'), updateAttendance);
-router.post('/delete/:attendance',  authService.ensureRoles('admin'), deleteAttendance);
+router.post('/create',  authService.ensureRole(), createAttendance);
+router.get('/read/:attendance',  authService.ensureRole(), readAttendance);
+router.post('/update/:attendance',  authService.ensureRole(), updateAttendance);
+router.post('/delete/:attendance',  authService.ensureRole(), deleteAttendance);
 
 module.exports = router;

--- a/controllers/CRUD/clientCRUD.js
+++ b/controllers/CRUD/clientCRUD.js
@@ -116,9 +116,9 @@ router.get('/fetch/:clientId', async (req, res, next) => {
     }
 });
 
-router.post('/create',  authService.ensureRoles('admin'), createClient);
-router.get('/read/:clientId',  authService.ensureRoles('admin'), readClient);
-router.post('/update/:clientId',  authService.ensureRoles('admin'), updateClient);
-router.post('/delete/:clientId',  authService.ensureRoles('admin'), deleteClient);
+router.post('/create',  authService.ensureRole(), createClient);
+router.get('/read/:clientId',  authService.ensureRole(), readClient);
+router.post('/update/:clientId',  authService.ensureRole(), updateClient);
+router.post('/delete/:clientId',  authService.ensureRole(), deleteClient);
 
 module.exports = router;

--- a/controllers/CRUD/employeeCRUD.js
+++ b/controllers/CRUD/employeeCRUD.js
@@ -75,9 +75,9 @@ router.get('/fetch/employee/:id', async (req, res, next) => {
     }
 });
 
-router.post('/create',  authService.ensureRoles('admin'), createEmployee);
-router.get('/read/:employee',  authService.ensureRoles('admin'), readEmployee)
-router.post('/update/:employee',  authService.ensureRoles('admin'), updateEmployee);
-router.post('/delete/:employee',  authService.ensureRoles('admin'), deleteEmployee);
+router.post('/create',  authService.ensureRole(), createEmployee);
+router.get('/read/:employee',  authService.ensureRole(), readEmployee)
+router.post('/update/:employee',  authService.ensureRole(), updateEmployee);
+router.post('/delete/:employee',  authService.ensureRole(), deleteEmployee);
 
 module.exports = router;

--- a/controllers/CRUD/invoiceCRUD.js
+++ b/controllers/CRUD/invoiceCRUD.js
@@ -213,10 +213,10 @@ router.get('fetch/unsubmittedinvoices', async (req, res, next) => {
     }
 });
 
-router.post('/create/:selected',  authService.ensureRoles('admin'), createInvoice);
-router.get('/read/:invoice',  authService.ensureRoles('admin'), readInvoice);
-router.get('/read/:subcontractor',  authService.ensureRoles('admin'), readInvoices);
-router.post('/update/:invoice',  authService.ensureRoles('admin'), updateInvoice);
-router.post('/delete/:invoice',  authService.ensureRoles('admin'), deleteInvoice);
+router.post('/create/:selected',  authService.ensureRole(), createInvoice);
+router.get('/read/:invoice',  authService.ensureRole(), readInvoice);
+router.get('/read/:subcontractor',  authService.ensureRole(), readInvoices);
+router.post('/update/:invoice',  authService.ensureRole(), updateInvoice);
+router.post('/delete/:invoice',  authService.ensureRole(), deleteInvoice);
 
 module.exports = router;

--- a/controllers/CRUD/jobCRUD.js
+++ b/controllers/CRUD/jobCRUD.js
@@ -119,9 +119,9 @@ router.get('/fetch/job/:id', async (req, res, next) => {
     }
 });
 
-router.get('/create/:quoteId',  authService.ensureRoles('admin'), createJob);
-router.get('/read/:jobId',  authService.ensureRoles('admin'), readJob);
-router.post('/update/:jobId',  authService.ensureRoles('admin'), updateJob);
-router.post('/delete/:jobId',  authService.ensureRoles('admin'), deleteJob);
+router.get('/create/:quoteId',  authService.ensureRole(), createJob);
+router.get('/read/:jobId',  authService.ensureRole(), readJob);
+router.post('/update/:jobId',  authService.ensureRole(), updateJob);
+router.post('/delete/:jobId',  authService.ensureRole(), deleteJob);
 
 module.exports = router;

--- a/controllers/CRUD/kashflow/customer.js
+++ b/controllers/CRUD/kashflow/customer.js
@@ -44,6 +44,6 @@ const readCustomer = async (req, res, next) => {
 };
 
 
-router.get('/customer/read/:uuid',  authService.ensureRoles('admin'), readCustomer);
+router.get('/customer/read/:uuid',  authService.ensureRole(), readCustomer);
 
 module.exports = router;

--- a/controllers/CRUD/kashflow/invoice.js
+++ b/controllers/CRUD/kashflow/invoice.js
@@ -38,6 +38,6 @@ const readInvoice = async (req, res, next) => {
 };
 
 
-router.get('/invoice/read/:uuid',  authService.ensureRoles('admin'), readInvoice);
+router.get('/invoice/read/:uuid',  authService.ensureRole(), readInvoice);
 
 module.exports = router;

--- a/controllers/CRUD/kashflow/project.js
+++ b/controllers/CRUD/kashflow/project.js
@@ -99,9 +99,9 @@ const viewFile = async (req, res, next) => {
     }
 };
 
-router.get('/project/read/:uuid',  authService.ensureRoles('admin'), readProject);
-router.get('/project/:uuid/serve/:filename',  authService.ensureRoles('admin'), serveFile);
-router.get('/project/:uuid/view/:filename',  authService.ensureRoles('admin'), viewFile);
+router.get('/project/read/:uuid',  authService.ensureRole(), readProject);
+router.get('/project/:uuid/serve/:filename',  authService.ensureRole(), serveFile);
+router.get('/project/:uuid/view/:filename',  authService.ensureRole(), viewFile);
 
 
 module.exports = router;

--- a/controllers/CRUD/kashflow/quote.js
+++ b/controllers/CRUD/kashflow/quote.js
@@ -38,6 +38,6 @@ const readQuote = async (req, res, next) => {
 };
 
 
-router.get('/quote/read/:uuid',  authService.ensureRoles('admin'), readQuote);
+router.get('/quote/read/:uuid',  authService.ensureRole(), readQuote);
 
 module.exports = router;

--- a/controllers/CRUD/kashflow/receipt.js
+++ b/controllers/CRUD/kashflow/receipt.js
@@ -42,9 +42,9 @@ const readReceipt = async (req, res, next) => {
     }
 };
 
-router.get('/receipt/read/:uuid',  authService.ensureRoles('admin'), readReceipt);
+router.get('/receipt/read/:uuid',  authService.ensureRole(), readReceipt);
 
-router.post('/receipt/:uuid/change',  authService.ensureRoles('admin'), async (req, res) => {
+router.post('/receipt/:uuid/change',  authService.ensureRole(), async (req, res) => {
     try {
         const receipt = await kf.KF_Receipts.findOne({ where: { uuid: req.params.uuid } });
 
@@ -62,7 +62,7 @@ router.post('/receipt/:uuid/change',  authService.ensureRoles('admin'), async (r
     }
 });
 
-router.post('/receipt/change',  authService.ensureRoles('admin'), async (req, res) => {
+router.post('/receipt/change',  authService.ensureRole(), async (req, res) => {
     try {
         const { submissionDate, uuids, redirectPath  } = req.body;
         const targetUUIDs = uuids?.length ? Array.isArray(uuids) ? uuids : [uuids] : [req.params.uuid];
@@ -86,7 +86,7 @@ router.post('/receipt/change',  authService.ensureRoles('admin'), async (req, re
     }
 });
 
-router.post('/receipt/:uuid/submit',  authService.ensureRoles('admin'), async (req, res) => {
+router.post('/receipt/:uuid/submit',  authService.ensureRole(), async (req, res) => {
     try {
         const receipt = await kf.KF_Receipts.findOne({ where: { uuid: req.params.uuid } });
 
@@ -106,7 +106,7 @@ router.post('/receipt/:uuid/submit',  authService.ensureRoles('admin'), async (r
     }
 });
 
-router.post('/receipt/:uuid/cancel',  authService.ensureRoles('admin'), async (req, res) => {
+router.post('/receipt/:uuid/cancel',  authService.ensureRole(), async (req, res) => {
     try {
         const receipt = await kf.KF_Receipts.findOne({ where: { uuid: req.params.uuid } });
 

--- a/controllers/CRUD/kashflow/supplier.js
+++ b/controllers/CRUD/kashflow/supplier.js
@@ -76,7 +76,7 @@ const changeSupplier = async (req, res, next) => {
     }
 }
 
-router.get('/supplier/read/:uuid',  authService.ensureRoles('admin'), readSupplier);
-router.get('/supplier/change/:uuid',  authService.ensureRoles('admin'), renderchangeSupplierForm);
-router.post('/supplier/change/:uuid',  authService.ensureRoles('admin'), changeSupplier);
+router.get('/supplier/read/:uuid',  authService.ensureRole(), readSupplier);
+router.get('/supplier/change/:uuid',  authService.ensureRole(), renderchangeSupplierForm);
+router.post('/supplier/change/:uuid',  authService.ensureRole(), changeSupplier);
 module.exports = router;

--- a/controllers/CRUD/locationCRUD.js
+++ b/controllers/CRUD/locationCRUD.js
@@ -123,9 +123,9 @@ router.get('/fetch/location/:id', async (req, res, next) => {
 });
 
 // Define routes
-router.post('/create',  authService.ensureRoles('admin'), createLocation);
-router.get('/read/:id',  authService.ensureRoles('admin'), readLocation);
-router.post('/update/:id',  authService.ensureRoles('admin'), updateLocation);
-router.post('/delete/:id',  authService.ensureRoles('admin'), deleteLocation);
+router.post('/create',  authService.ensureRole(), createLocation);
+router.get('/read/:id',  authService.ensureRole(), readLocation);
+router.post('/update/:id',  authService.ensureRole(), updateLocation);
+router.post('/delete/:id',  authService.ensureRole(), deleteLocation);
 
 module.exports = router;

--- a/controllers/CRUD/quoteCRUD.js
+++ b/controllers/CRUD/quoteCRUD.js
@@ -161,10 +161,10 @@ router.get('/fetch/quote/:quoteId', async (req, res, next) => {
 });
 
 
-router.post('/create/:client',  authService.ensureRoles('admin'), createQuote);
-router.get('/read/:quoteId',  authService.ensureRoles('admin'), readQuote);
-router.get('/read/:client',  authService.ensureRoles('admin'), readQuotes);
-router.post('/update/:id',  authService.ensureRoles('admin'), updateQuote);
-router.post('/delete/:id',  authService.ensureRoles('admin'), deleteQuote);
+router.post('/create/:client',  authService.ensureRole(), createQuote);
+router.get('/read/:quoteId',  authService.ensureRole(), readQuote);
+router.get('/read/:client',  authService.ensureRole(), readQuotes);
+router.post('/update/:id',  authService.ensureRole(), updateQuote);
+router.post('/delete/:id',  authService.ensureRole(), deleteQuote);
 
 module.exports = router;

--- a/controllers/CRUD/subcontractorCRUD.js
+++ b/controllers/CRUD/subcontractorCRUD.js
@@ -202,7 +202,7 @@ const deleteSubcontractor = async (req, res, next, error) => {
     }
 };
 
-router.get('/fetch/subcontractor/:id',  authService.ensureRoles('admin'), async (req, res, next) => {
+router.get('/fetch/subcontractor/:id',  authService.ensureRole(), async (req, res, next) => {
     try {
         const subcontractor = await db.Subcontractors.findAll({
             where: { id: req.params.id },
@@ -234,9 +234,9 @@ router.get('/fetch/subcontractor/:id',  authService.ensureRoles('admin'), async 
     }
 });
 
-router.post('/create',  authService.ensureRoles('admin'), createSubcontractor);
-router.get('/read/:id',  authService.ensureRoles('admin'), readSubcontractor);
-router.post('/update/:id',  authService.ensureRoles('admin'), updateSubcontractor);
-router.post('/delete/:id',  authService.ensureRoles('admin'), deleteSubcontractor);
+router.post('/create',  authService.ensureRole(), createSubcontractor);
+router.get('/read/:id',  authService.ensureRole(), readSubcontractor);
+router.post('/update/:id',  authService.ensureRole(), updateSubcontractor);
+router.post('/delete/:id',  authService.ensureRole(), deleteSubcontractor);
 
 module.exports = router;

--- a/controllers/CRUD/userCRUD.js
+++ b/controllers/CRUD/userCRUD.js
@@ -181,9 +181,9 @@ router.get('/fetch/user/:id', async (req, res, next) => {
     }
 });
 
-router.post('/create',  authService.ensureRoles('admin'), createUser);
-router.get('/read/:id',  authService.ensureRoles('admin'), readUser);
-router.post('/update/:id',  authService.ensureRoles('admin'), updateUser);
-router.post('/delete/:id',  authService.ensureRoles('admin'), deleteUser);
+router.post('/create',  authService.ensureRole(), createUser);
+router.get('/read/:id',  authService.ensureRole(), readUser);
+router.post('/update/:id',  authService.ensureRole(), updateUser);
+router.post('/delete/:id',  authService.ensureRole(), deleteUser);
 
 module.exports = router;

--- a/controllers/admin/logger.js
+++ b/controllers/admin/logger.js
@@ -5,7 +5,7 @@ const readline = require('readline');
 const authService = require('../../services/authService');
 const router = express.Router();
 /*
-router.get('/logs',  authService.ensureRoles('admin'), async (req, res) => {
+router.get('/logs',  authService.ensureRole(), async (req, res) => {
     const logPath = path.join(__dirname, '..', '..', 'logs', 'app.log');
     const lines = [];
 
@@ -29,7 +29,7 @@ router.get('/logs',  authService.ensureRoles('admin'), async (req, res) => {
     });
 });
 */
-router.get('/logs',  authService.ensureRoles('admin'), async (req, res) => {
+router.get('/logs',  authService.ensureRole(), async (req, res) => {
     const logPath = path.join(__dirname, '..', '..', 'logs', 'app.json.log');
     const logsByLevel = {
         info: [],

--- a/controllers/dailyAttendance.js
+++ b/controllers/dailyAttendance.js
@@ -52,6 +52,6 @@ const getDailyAttendance = async (req, res, next) => {
  * @param {Function} authService.ensureRoles - Middleware to ensure user has 'admin' role.
  * @param {Function} getDailyAttendance - Controller function to handle the route.
  */
-router.get('/daily/:date?',  authService.ensureRoles('admin'), getDailyAttendance);
+router.get('/daily/:date?',  authService.ensureRole(), getDailyAttendance);
 
 module.exports = router;

--- a/controllers/fetch/user.js
+++ b/controllers/fetch/user.js
@@ -4,7 +4,7 @@ const logger = require('../../services/loggerService');
 const db = require('../../services/sequelizeDatabaseService');
 const authService = require('../../services/authService');
 
-router.get('/fetch/user/:id',  authService.ensureRoles('admin'), async (req, res, next) => {
+router.get('/fetch/user/:id',  authService.ensureRole(), async (req, res, next) => {
     try {
         const user = await db.Users.findAll({
             where: { id: req.params.id },

--- a/controllers/fileSystemProjects.js
+++ b/controllers/fileSystemProjects.js
@@ -48,7 +48,7 @@ const upload = multer({
     limits: { fileSize: 5 * 1024 * 1024 } // 5MB file size limit
 });
 
-router.post('/project/:uuid/:number/upload',  authService.ensureRoles('admin'), upload.array('files', 10), (req, res) => {
+router.post('/project/:uuid/:number/upload',  authService.ensureRole(), upload.array('files', 10), (req, res) => {
     const projectDir = path.join(projectsDir, req.params.number.toString());
     req.files.forEach(file => {
         const sanitizedFileName = sanitize(file.originalname);
@@ -58,7 +58,7 @@ router.post('/project/:uuid/:number/upload',  authService.ensureRoles('admin'), 
     res.redirect(`/kashflow/project/read/${req.params.uuid}`);
 });
 
-router.get('/project/:uuid/:number/download/:filename',  authService.ensureRoles('admin'), (req, res) => {
+router.get('/project/:uuid/:number/download/:filename',  authService.ensureRole(), (req, res) => {
         const sanitizedFileName = sanitize(req.params.filename);
         const filePath = path.join(projectsDir, req.params.number.toString(), sanitizedFileName);
 

--- a/controllers/forms/attendance.js
+++ b/controllers/forms/attendance.js
@@ -73,7 +73,7 @@ const renderAttendanceUpdateForm = async (req, res, next) => {
 
 
 
-router.get('/create',  authService.ensureRoles('admin'), renderAttendanceCreateForm);
-router.get('/update/:attendance',  authService.ensureRoles('admin'), renderAttendanceUpdateForm);
+router.get('/create',  authService.ensureRole(), renderAttendanceCreateForm);
+router.get('/update/:attendance',  authService.ensureRole(), renderAttendanceUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/client.js
+++ b/controllers/forms/client.js
@@ -63,7 +63,7 @@ const renderClientUpdateForm = async (req, res, next) => {
 };
 
 //router.get('/client/select', selectClient);
-router.get('/create',  authService.ensureRoles('admin'), renderClientCreateForm);
-router.get('/update/:client',  authService.ensureRoles('admin'), renderClientUpdateForm);
+router.get('/create',  authService.ensureRole(), renderClientCreateForm);
+router.get('/update/:client',  authService.ensureRole(), renderClientUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/contact.js
+++ b/controllers/forms/contact.js
@@ -87,7 +87,7 @@ const renderContactUpdateForm = async (req, res, next) => {
 };
 
 //router.get('/contact/select', selectContact);
-router.get('/create',  authService.ensureRoles('admin'), renderContactCreateForm);
-router.get('/update/:contact',  authService.ensureRoles('admin'), renderContactUpdateForm);
+router.get('/create',  authService.ensureRole(), renderContactCreateForm);
+router.get('/update/:contact',  authService.ensureRole(), renderContactUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/employee.js
+++ b/controllers/forms/employee.js
@@ -35,7 +35,7 @@ const renderUpdateEmployeeForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderCreateEmployeeForm);
-router.get('/update/:employee',  authService.ensureRoles('admin'), renderUpdateEmployeeForm);
+router.get('/create',  authService.ensureRole(), renderCreateEmployeeForm);
+router.get('/update/:employee',  authService.ensureRole(), renderUpdateEmployeeForm);
 
 module.exports = router;

--- a/controllers/forms/invoice.js
+++ b/controllers/forms/invoice.js
@@ -48,7 +48,7 @@ const renderInvoiceUpdateForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderInvoiceCreateForm);
-router.get('/update/:invoice',  authService.ensureRoles('admin'), renderInvoiceUpdateForm);
+router.get('/create',  authService.ensureRole(), renderInvoiceCreateForm);
+router.get('/update/:invoice',  authService.ensureRole(), renderInvoiceUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/job.js
+++ b/controllers/forms/job.js
@@ -59,7 +59,7 @@ const renderJobUpdateForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderJobCreateForm);
-router.get('/update/:jobId',  authService.ensureRoles('admin'), renderJobUpdateForm);
+router.get('/create',  authService.ensureRole(), renderJobCreateForm);
+router.get('/update/:jobId',  authService.ensureRole(), renderJobUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/location.js
+++ b/controllers/forms/location.js
@@ -46,7 +46,7 @@ const renderLocationUpdateForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderLocationCreateForm);
-router.get('/update/:locationId',  authService.ensureRoles('admin'), renderLocationUpdateForm);
+router.get('/create',  authService.ensureRole(), renderLocationCreateForm);
+router.get('/update/:locationId',  authService.ensureRole(), renderLocationUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/quote.js
+++ b/controllers/forms/quote.js
@@ -66,7 +66,7 @@ const renderQuoteUpdateForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderQuoteCreateForm);
-router.get('/update/:quote',  authService.ensureRoles('admin'), renderQuoteUpdateForm);
+router.get('/create',  authService.ensureRole(), renderQuoteCreateForm);
+router.get('/update/:quote',  authService.ensureRole(), renderQuoteUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/subcontractor.js
+++ b/controllers/forms/subcontractor.js
@@ -72,7 +72,7 @@ const renderSubcontractorUpdateForm = async (req, res, next) => {
 };
 
 //router.get('/select', selectSubcontractor);
-router.get('/create',  authService.ensureRoles('admin'), renderSubcontractorCreateForm);
-router.get('/update/:subcontractor',  authService.ensureRoles('admin'), renderSubcontractorUpdateForm);
+router.get('/create',  authService.ensureRole(), renderSubcontractorCreateForm);
+router.get('/update/:subcontractor',  authService.ensureRole(), renderSubcontractorUpdateForm);
 
 module.exports = router;

--- a/controllers/forms/user.js
+++ b/controllers/forms/user.js
@@ -43,7 +43,7 @@ const renderUserUpdateForm = async (req, res, next) => {
     }
 };
 
-router.get('/create',  authService.ensureRoles('admin'), renderUserCreateForm);
-router.get('/update/:user',  authService.ensureRoles('admin'), renderUserUpdateForm);
+router.get('/create',  authService.ensureRole(), renderUserCreateForm);
+router.get('/update/:user',  authService.ensureRole(), renderUserUpdateForm);
 
 module.exports = router;

--- a/controllers/kashflowMonthlyReturns.js
+++ b/controllers/kashflowMonthlyReturns.js
@@ -167,7 +167,7 @@ const renderKFMonthlyReturns = async (req, res, next) => {
     }
 };
 
-router.get('/returns/form',  authService.ensureRoles('admin'), renderKFMonthlyReturnsForm);
-router.get('/returns/:month/:year/:uuid',  authService.ensureRoles('admin'), renderKFMonthlyReturns);
+router.get('/returns/form',  authService.ensureRole(), renderKFMonthlyReturnsForm);
+router.get('/returns/:month/:year/:uuid',  authService.ensureRole(), renderKFMonthlyReturns);
 
 module.exports = router;

--- a/controllers/kashflowYearlyReturns.js
+++ b/controllers/kashflowYearlyReturns.js
@@ -456,6 +456,6 @@ router.post('/download-xlsx', async (req, res) => {
     }
 });
 
-router.get('/returns/:year/:uuid',  authService.ensureRoles('admin'), renderKFYearlyReturns);
+router.get('/returns/:year/:uuid',  authService.ensureRole(), renderKFYearlyReturns);
 
 module.exports = router;

--- a/controllers/mongoose/receipts.js
+++ b/controllers/mongoose/receipts.js
@@ -165,8 +165,8 @@ const renderCISDashboardMongo = async (req, res, next) => {
   }
 };
 
-router.get('/mdb/CIS/:year/:month',  authService.ensureRoles('admin'), renderCISDashboardMongo);
-router.get('/mdb/CIS',  authService.ensureRoles('admin'), (req, res) => {
+router.get('/mdb/CIS/:year/:month',  authService.ensureRole(), renderCISDashboardMongo);
+router.get('/mdb/CIS',  authService.ensureRole(), (req, res) => {
   const { taxYear, taxMonth } = taxService.calculateTaxYearAndMonth(moment());
   return res.redirect(`/mdb/CIS/${taxYear}/${taxMonth}`);
 });

--- a/controllers/monthlyReturns.js
+++ b/controllers/monthlyReturns.js
@@ -204,9 +204,9 @@ const renderMonthlyReturnsYear = async (req, res, next) => {
     }
 };
 
-router.get('/returns/form',  authService.ensureRoles('admin'), renderMonthlyReturnsForm);
-router.get('/returns/:month/:year/:id',  authService.ensureRoles('admin'), renderMonthlyReturnsForOneSubcontactor);
-router.get('/returns/:year/:month',  authService.ensureRoles('admin'), renderMonthlyReturnsForAll);
-router.get('/returns/:year',  authService.ensureRoles('admin'), renderMonthlyReturnsYear);
+router.get('/returns/form',  authService.ensureRole(), renderMonthlyReturnsForm);
+router.get('/returns/:month/:year/:id',  authService.ensureRole(), renderMonthlyReturnsForOneSubcontactor);
+router.get('/returns/:year/:month',  authService.ensureRole(), renderMonthlyReturnsForAll);
+router.get('/returns/:year',  authService.ensureRole(), renderMonthlyReturnsYear);
 
 module.exports = router;

--- a/controllers/renderDashboards.js
+++ b/controllers/renderDashboards.js
@@ -730,7 +730,7 @@ const renderKashflowDashboard = async (req, res, next) => {
     }
 };
 
-router.get('/stats',  authService.ensureRoles('admin'), (req, res) => {
+router.get('/stats',  authService.ensureRole(), (req, res) => {
     try {
         const { taxYear, taxMonth } = taxService.calculateTaxYearAndMonth(moment());
         logger.info(`Tax Year: ${taxYear}, Tax Month: ${taxMonth}`);
@@ -741,26 +741,26 @@ router.get('/stats',  authService.ensureRoles('admin'), (req, res) => {
         next(error); // Pass the error to the error handler
     }
 });
-router.get('/stats/:year?/:month?',  authService.ensureRoles('admin'), renderStatsDashboard);
-router.get('/user',  authService.ensureRoles('admin'), renderUserDashboard);
-router.get('/subcontractor',  authService.ensureRoles('admin'), renderSubcontractorDashboard);
-router.get('/invoice',  authService.ensureRoles('admin'), renderInvoiceDashboard);
-router.get('/quote',  authService.ensureRoles('admin'), renderQuotesDashboard);
-router.get('/client',  authService.ensureRoles('admin'), renderClientsDashboard);
-router.get('/contact',  authService.ensureRoles('admin'), renderContactsDashboard);
-router.get('/job',  authService.ensureRoles('admin'), renderJobsDashboard);
-//router.get('/archive',  authService.ensureRoles('admin'), renderQuoteArchiveDashboard);
-router.get('/location',  authService.ensureRoles('admin'), renderLocationsDashboard);
-router.get('/attendance',  authService.ensureRoles('admin'), renderAttendanceDashboard);
-router.get('/employee',  authService.ensureRoles('admin'), renderEmployeeDashboard);
+router.get('/stats/:year?/:month?',  authService.ensureRole(), renderStatsDashboard);
+router.get('/user',  authService.ensureRole(), renderUserDashboard);
+router.get('/subcontractor',  authService.ensureRole(), renderSubcontractorDashboard);
+router.get('/invoice',  authService.ensureRole(), renderInvoiceDashboard);
+router.get('/quote',  authService.ensureRole(), renderQuotesDashboard);
+router.get('/client',  authService.ensureRole(), renderClientsDashboard);
+router.get('/contact',  authService.ensureRole(), renderContactsDashboard);
+router.get('/job',  authService.ensureRole(), renderJobsDashboard);
+//router.get('/archive',  authService.ensureRole(), renderQuoteArchiveDashboard);
+router.get('/location',  authService.ensureRole(), renderLocationsDashboard);
+router.get('/attendance',  authService.ensureRole(), renderAttendanceDashboard);
+router.get('/employee',  authService.ensureRole(), renderEmployeeDashboard);
 
-router.get('/KFcustomer',  authService.ensureRoles('admin'), renderKFCustomersDashboard);
-router.get('/KFinvoice',  authService.ensureRoles('admin'), renderKFInvoicesDashboard);
-router.get('/KFquote',  authService.ensureRoles('admin'), renderKFQuotesDashboard);
-router.get('/KFsupplier',  authService.ensureRoles('admin'), renderKFSuppliersDashboard);
-router.get('/KFreceipt',  authService.ensureRoles('admin'), renderKFReceiptsDashboard);
-router.get('/KFproject',  authService.ensureRoles('admin'), renderKFProjectsDashboard);
-router.get('/KF',  authService.ensureRoles('admin'), renderKashflowDashboard);
+router.get('/KFcustomer',  authService.ensureRole(), renderKFCustomersDashboard);
+router.get('/KFinvoice',  authService.ensureRole(), renderKFInvoicesDashboard);
+router.get('/KFquote',  authService.ensureRole(), renderKFQuotesDashboard);
+router.get('/KFsupplier',  authService.ensureRole(), renderKFSuppliersDashboard);
+router.get('/KFreceipt',  authService.ensureRole(), renderKFReceiptsDashboard);
+router.get('/KFproject',  authService.ensureRole(), renderKFProjectsDashboard);
+router.get('/KF',  authService.ensureRole(), renderKashflowDashboard);
 
 const renderCISSubmissionDashboard = async (req, res, next) => {
     try {
@@ -1031,7 +1031,7 @@ const renderCISDashboard = async (req, res, next) => {
 };
 
 
-router.get('/CIS',  authService.ensureRoles('admin'), (req, res) => {
+router.get('/CIS',  authService.ensureRole(), (req, res) => {
     try {
         const { taxYear, taxMonth } = taxService.calculateTaxYearAndMonth(moment());
         return res.redirect(`/dashboard/CIS/${taxYear}/${taxMonth}`);
@@ -1042,7 +1042,7 @@ router.get('/CIS',  authService.ensureRoles('admin'), (req, res) => {
     }
 });
 
-router.get('/CIS/:year?/:month?',  authService.ensureRoles('admin'), renderCISDashboard);
+router.get('/CIS/:year?/:month?',  authService.ensureRole(), renderCISDashboard);
 
 const renderKFSubcontractorDashboard = async (req, res, next) => {
     try {
@@ -1062,6 +1062,6 @@ const renderKFSubcontractorDashboard = async (req, res, next) => {
     }
 };
 
-router.get('/KFsubcontractor',  authService.ensureRoles('admin'), renderKFSubcontractorDashboard);
+router.get('/KFsubcontractor',  authService.ensureRole(), renderKFSubcontractorDashboard);
 
 module.exports = router;

--- a/controllers/renderVerification.js
+++ b/controllers/renderVerification.js
@@ -57,8 +57,8 @@ const renderClientVerification = async (req, res, next) => {
     }
 };
 
-router.get('/subcontractor',  authService.ensureRoles('admin'), renderSubcontractorVerification);
-router.get('/invoice',  authService.ensureRoles('admin'), renderInvoiceVerification);
-router.get('/client',  authService.ensureRoles('admin'), renderClientVerification);
+router.get('/subcontractor',  authService.ensureRole(), renderSubcontractorVerification);
+router.get('/invoice',  authService.ensureRole(), renderInvoiceVerification);
+router.get('/client',  authService.ensureRole(), renderClientVerification);
 
 module.exports = router;

--- a/controllers/weeklyAttendance.js
+++ b/controllers/weeklyAttendance.js
@@ -89,7 +89,7 @@ const getWeeklyAttendance = async (req, res, next) => {
 };
 
 // Redirect `/attendance/weekly` to the current week's attendance
-router.get('/weekly',  authService.ensureRoles('admin'), (req, res, next) => {
+router.get('/weekly',  authService.ensureRole(), (req, res, next) => {
     try {
         const currentTaxYear = taxService.getCurrentTaxYear();
         const { start: startOfTaxYear, end: endOfTaxYear } = taxService.getTaxYearStartEnd(currentTaxYear);
@@ -115,6 +115,6 @@ router.get('/weekly',  authService.ensureRoles('admin'), (req, res, next) => {
     }
 });
 
-router.get('/weekly/:year?/:week?',  authService.ensureRoles('admin'), getWeeklyAttendance);
+router.get('/weekly/:year?/:week?',  authService.ensureRole(), getWeeklyAttendance);
 
 module.exports = router;

--- a/controllers/yearlyReturns.js
+++ b/controllers/yearlyReturns.js
@@ -73,6 +73,6 @@ const renderYearlyReturns = async (req, res, next) => {
     }
 };
 
-router.get('/returns/:year/:id',  authService.ensureRoles('admin'), renderYearlyReturns);
+router.get('/returns/:year/:id',  authService.ensureRole(), renderYearlyReturns);
 
 module.exports = router;

--- a/mongoose/routes/attendanceCrud.js
+++ b/mongoose/routes/attendanceCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/attendanceCRUDController');
 
-router.post('/attendance/create', ctrl.createAttendance);
-router.get('/attendance/read/:uuid', ctrl.readAttendance);
-router.post('/attendance/update/:uuid', ctrl.updateAttendance);
-router.post('/attendance/delete/:uuid', ctrl.deleteAttendance);
+router.post('/attendance/create', auth.ensureRole(), ctrl.createAttendance);
+router.get('/attendance/read/:uuid', auth.ensureRole(), ctrl.readAttendance);
+router.post('/attendance/update/:uuid', auth.ensureRole(), ctrl.updateAttendance);
+router.post('/attendance/delete/:uuid', auth.ensureRole(), ctrl.deleteAttendance);
 
 module.exports = router;

--- a/mongoose/routes/cis.js
+++ b/mongoose/routes/cis.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const cis = require('../controllers/cisController');
 
-router.get('/mdb/CIS/:year/:month', cis.renderCISDashboardMongo);
-router.get('/mdb/CIS', cis.redirectCIS);
+router.get('/mdb/CIS/:year/:month', auth.ensureRole(), cis.renderCISDashboardMongo);
+router.get('/mdb/CIS', auth.ensureRole(), cis.redirectCIS);
 
 module.exports = router;

--- a/mongoose/routes/customers.js
+++ b/mongoose/routes/customers.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const customers = require('../controllers/customersController');
 
-router.get('/customers', customers.listCustomers);
-router.get('/customer/read/:uuid', customers.viewCustomer);
+router.get('/customers', auth.ensureRole(), customers.listCustomers);
+router.get('/customer/read/:uuid', auth.ensureRole(), customers.viewCustomer);
 
 module.exports = router;

--- a/mongoose/routes/dailyAttendance.js
+++ b/mongoose/routes/dailyAttendance.js
@@ -3,6 +3,6 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/dailyAttendanceController');
 
-router.get('/attendance/daily/:date?', ctrl.getDailyAttendance);
+router.get('/attendance/daily/:date?', auth.ensureRole(), ctrl.getDailyAttendance);
 
 module.exports = router;

--- a/mongoose/routes/employeeCrud.js
+++ b/mongoose/routes/employeeCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/employeeCRUDController');
 
-router.post('/employee/create', ctrl.createEmployee);
-router.get('/employee/read/:uuid', ctrl.readEmployee);
-router.post('/employee/update/:uuid', ctrl.updateEmployee);
-router.post('/employee/delete/:uuid', ctrl.deleteEmployee);
+router.post('/employee/create', auth.ensureRole(), ctrl.createEmployee);
+router.get('/employee/read/:uuid', auth.ensureRole(), ctrl.readEmployee);
+router.post('/employee/update/:uuid', auth.ensureRole(), ctrl.updateEmployee);
+router.post('/employee/delete/:uuid', auth.ensureRole(), ctrl.deleteEmployee);
 
 module.exports = router;

--- a/mongoose/routes/indexRoutes.js
+++ b/mongoose/routes/indexRoutes.js
@@ -3,12 +3,12 @@ const router = express.Router();
 const authService = require('../../services/authService');
 const index = require('../controllers/indexController');
 
-router.get('/', index.renderIndex);
-router.get('/construction-industry-scheme',  index.renderConstructionIndustryScheme);
-router.get('/management',  index.renderManagement);
-router.get('/payroll',  index.renderPayroll);
-router.get('/human-resources',  index.renderHumanResources);
-router.get('/kashflow',  index.renderKashflow);
-router.get('/create',  index.renderCreate);
+router.get('/', authService.ensureRole('none'), index.renderIndex);
+router.get('/construction-industry-scheme', authService.ensureRole(), index.renderConstructionIndustryScheme);
+router.get('/management', authService.ensureRole(), index.renderManagement);
+router.get('/payroll', authService.ensureRole(), index.renderPayroll);
+router.get('/human-resources', authService.ensureRole(), index.renderHumanResources);
+router.get('/kashflow', authService.ensureRole(), index.renderKashflow);
+router.get('/create', authService.ensureRole(), index.renderCreate);
 
 module.exports = router;

--- a/mongoose/routes/invoices.js
+++ b/mongoose/routes/invoices.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const invoices = require('../controllers/invoicesController');
 
-router.get('/invoices', invoices.listInvoices);
-router.get('/invoice/read/:uuid', invoices.viewInvoice);
+router.get('/invoices', auth.ensureRole(), invoices.listInvoices);
+router.get('/invoice/read/:uuid', auth.ensureRole(), invoices.viewInvoice);
 
 module.exports = router;

--- a/mongoose/routes/locationCrud.js
+++ b/mongoose/routes/locationCrud.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/locationCRUDController');
 
-router.post('/location/create', ctrl.createLocation);
-router.get('/location/read/:uuid', ctrl.readLocation);
-router.post('/location/update/:uuid', ctrl.updateLocation);
-router.post('/location/delete/:uuid', ctrl.deleteLocation);
+router.post('/location/create', auth.ensureRole(), ctrl.createLocation);
+router.get('/location/read/:uuid', auth.ensureRole(), ctrl.readLocation);
+router.post('/location/update/:uuid', auth.ensureRole(), ctrl.updateLocation);
+router.post('/location/delete/:uuid', auth.ensureRole(), ctrl.deleteLocation);
 
 module.exports = router;

--- a/mongoose/routes/login.js
+++ b/mongoose/routes/login.js
@@ -3,8 +3,8 @@ const router = express.Router();
 const login = require('../controllers/loginController');
 const authService = require('../../services/authService');
 
-router.get('/user/login', authService.doesntRequireLogin, login.renderLoginForm);
-router.post('/user/login', authService.doesntRequireLogin, login.loginUser);
+router.get('/user/login', authService.ensureRole('none'), authService.doesntRequireLogin, login.renderLoginForm);
+router.post('/user/login', authService.ensureRole('none'), authService.doesntRequireLogin, login.loginUser);
 router.get('/user/logout', login.logoutUser);
 
 module.exports = router;

--- a/mongoose/routes/monthlyReturns.js
+++ b/mongoose/routes/monthlyReturns.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/monthlyReturnsController');
 
-router.get('/monthly/returns/form', ctrl.renderMonthlyReturnsForm);
-router.get('/monthly/returns/:month/:year/:uuid', ctrl.renderMonthlyReturns);
+router.get('/monthly/returns/form', auth.ensureRole(), ctrl.renderMonthlyReturnsForm);
+router.get('/monthly/returns/:month/:year/:uuid', auth.ensureRole(), ctrl.renderMonthlyReturns);
 
 module.exports = router;

--- a/mongoose/routes/quotes.js
+++ b/mongoose/routes/quotes.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const quotes = require('../controllers/quotesController');
 
-router.get('/quotes', quotes.listQuotes);
-router.get('/quote/read/:uuid', quotes.viewQuote);
+router.get('/quotes', auth.ensureRole(), quotes.listQuotes);
+router.get('/quote/read/:uuid', auth.ensureRole(), quotes.viewQuote);
 
 module.exports = router;

--- a/mongoose/routes/receipts.js
+++ b/mongoose/routes/receipts.js
@@ -3,8 +3,8 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const receipts = require('../controllers/receiptsListController');
 
-router.get('/receipts', receipts.listReceipts);
-router.get('/receipt/read/:uuid', receipts.viewReceipt);
-router.post('/receipt/change', receipts.changeReceipts);
+router.get('/receipts', auth.ensureRole(), receipts.listReceipts);
+router.get('/receipt/read/:uuid', auth.ensureRole(), receipts.viewReceipt);
+router.post('/receipt/change', auth.ensureRole(), receipts.changeReceipts);
 
 module.exports = router;

--- a/mongoose/routes/register.js
+++ b/mongoose/routes/register.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const register = require('../controllers/registerController');
 const authService = require('../../services/authService');
 
-router.get('/user/register', authService.doesntRequireLogin, register.renderRegistrationForm);
-router.post('/user/register', authService.doesntRequireLogin, register.registerUser);
+router.get('/user/register', authService.ensureRole('none'), authService.doesntRequireLogin, register.renderRegistrationForm);
+router.post('/user/register', authService.ensureRole('none'), authService.doesntRequireLogin, register.registerUser);
 
 module.exports = router;

--- a/mongoose/routes/settings.js
+++ b/mongoose/routes/settings.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const settings = require('../controllers/settingsController');
 
-router.get('/user/profile',  settings.getProfilePage);
-router.get('/user/account',  settings.getAccountPage);
-router.post('/user/account/settings',  settings.validateAccountSettings, settings.updateAccountSettings);
-router.post('/user/account/logout-session',  settings.logoutSession);
+router.get('/user/profile', auth.ensureRole(), settings.getProfilePage);
+router.get('/user/account', auth.ensureRole(), settings.getAccountPage);
+router.post('/user/account/settings', auth.ensureRole(), settings.validateAccountSettings, settings.updateAccountSettings);
+router.post('/user/account/logout-session', auth.ensureRole(), settings.logoutSession);
 
 module.exports = router;

--- a/mongoose/routes/suppliers.js
+++ b/mongoose/routes/suppliers.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const suppliers = require('../controllers/suppliersController');
 
-router.get('/suppliers', suppliers.listSuppliers);
-router.get('/supplier/read/:uuid', suppliers.viewSupplier);
+router.get('/suppliers', auth.ensureRole(), suppliers.listSuppliers);
+router.get('/supplier/read/:uuid', auth.ensureRole(), suppliers.viewSupplier);
 
 module.exports = router;

--- a/mongoose/routes/twoFA.js
+++ b/mongoose/routes/twoFA.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const twoFA = require('../controllers/twoFAController');
+const auth = require('../../services/authService');
 
-router.get('/user/2fa', twoFA.render2FAPage);
-router.post('/user/2fa', twoFA.verify2FA);
+router.get('/user/2fa', auth.ensureRole('none'), twoFA.render2FAPage);
+router.post('/user/2fa', auth.ensureRole('none'), twoFA.verify2FA);
 
 module.exports = router;

--- a/mongoose/routes/weeklyAttendance.js
+++ b/mongoose/routes/weeklyAttendance.js
@@ -3,10 +3,10 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/weeklyAttendanceController');
 
-router.get('/attendance/weekly', (req,res,next)=>{
+router.get('/attendance/weekly', auth.ensureRole(), (req,res,next)=>{
   const currentYear = require('../../services/taxService').getCurrentTaxYear();
   res.redirect(`/attendance/weekly/${currentYear}`);
 });
-router.get('/attendance/weekly/:year?/:week?', ctrl.getWeeklyAttendance);
+router.get('/attendance/weekly/:year?/:week?', auth.ensureRole(), ctrl.getWeeklyAttendance);
 
 module.exports = router;

--- a/mongoose/routes/yearlyReturns.js
+++ b/mongoose/routes/yearlyReturns.js
@@ -3,6 +3,6 @@ const router = express.Router();
 const auth = require('../../services/authService');
 const ctrl = require('../controllers/yearlyReturnsController');
 
-router.get('/yearly/returns/:year/:uuid', ctrl.renderYearlyReturns);
+router.get('/yearly/returns/:year/:uuid', auth.ensureRole(), ctrl.renderYearlyReturns);
 
 module.exports = router;

--- a/services/authService.js
+++ b/services/authService.js
@@ -45,9 +45,16 @@ function ensureRoles(...roles) {
   };
 }
 
+// Default role-based middleware
+function ensureRole(role = 'admin') {
+  if (role === 'none') return (req, res, next) => next();
+  return ensureRoles(role);
+}
+
 module.exports = {
   ensureAuthenticated,
   requireLogin,
   doesntRequireLogin,
   ensureRoles,
+  ensureRole,
 };


### PR DESCRIPTION
## Summary
- add `ensureRole` helper with default `admin` enforcement
- protect routes with `ensureRole`
- allow public access on `/`, `/user/login`, and `/user/register`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4b65cf4832ab4120cf8a98212bd