### PR TITLE
Add mongoose user CRUD controller

### DIFF
--- a/mongoose/controllers/userCRUDController.js
+++ b/mongoose/controllers/userCRUDController.js
@@ -1,0 +1,43 @@
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+
+exports.createUser = async (req, res, next) => {
+  try {
+    const user = await mdb.user.create(req.body);
+    res.json({ user });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.readUser = async (req, res, next) => {
+  try {
+    const user = await mdb.user.findOne({ uuid: req.params.uuid });
+    if (!user) return res.status(404).send('Not found');
+    res.json({ user });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.updateUser = async (req, res, next) => {
+  try {
+    const user = await mdb.user.findOneAndUpdate(
+      { uuid: req.params.uuid },
+      req.body,
+      { new: true }
+    );
+    if (!user) return res.status(404).send('Not found');
+    res.json({ user });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteUser = async (req, res, next) => {
+  try {
+    await mdb.user.findOneAndDelete({ uuid: req.params.uuid });
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/mongoose/routes/userCrud.js
+++ b/mongoose/routes/userCrud.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../../services/authService');
+const ctrl = require('../controllers/userCRUDController');
+
+router.post('/user/create', ctrl.createUser);
+router.get('/user/read/:uuid', ctrl.readUser);
+router.post('/user/update/:uuid', ctrl.updateUser);
+router.post('/user/delete/:uuid', ctrl.deleteUser);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement CRUD operations for User model in Mongoose controllers
- expose new CRUD routes for users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852b53dfa28832a9ff370b16f624063