### PR TITLE
Add job registration and weekly schedule

### DIFF
--- a/models/mongoose/job.js
+++ b/models/mongoose/job.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const jobSchema = new mongoose.Schema({
+  uuid: { type: String, unique: true, required: true, default: uuidv4 },
+  jobRef: { type: String, required: true },
+  quoteRef: { type: String },
+  projectId: { type: mongoose.Schema.Types.ObjectId, ref: 'project' },
+  locationId: { type: mongoose.Schema.Types.ObjectId, ref: 'location' },
+  description: String,
+  startDate: Date,
+  endDate: Date,
+  status: { type: String, enum: ['scheduled','active','completed','archived'], default: 'scheduled' }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('job', jobSchema);

--- a/mongoose/controllers/jobsController.js
+++ b/mongoose/controllers/jobsController.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
+
+exports.renderJobForm = async (req,res,next)=>{
+  try {
+    const projects = await mdb.project.find({ Status: 1 }).sort({ Date1: -1 }).lean();
+    const locations = await mdb.location.find().sort({ name: 1 }).lean();
+    const jobs = await mdb.job.find().populate('projectId').populate('locationId').sort({ createdAt:-1 }).lean();
+    res.render(path.join('mongoose','jobRegistration'),{
+      title:'Job Registration',
+      projects,
+      locations,
+      jobs
+    });
+  } catch(err){ next(err); }
+};
+
+exports.registerJob = async (req,res,next)=>{
+  try {
+    const { jobRef, quoteRef, projectId, locationId, description, startDate, endDate } = req.body;
+    const job = new mdb.job({
+      jobRef,
+      quoteRef: quoteRef || null,
+      projectId: projectId || null,
+      locationId: locationId || null,
+      description,
+      startDate: startDate || null,
+      endDate: endDate || null,
+      status: 'scheduled'
+    });
+    await job.save();
+    req.flash('success','Job registered');
+    res.redirect('/job/register');
+  }catch(err){ next(err); }
+};
+
+exports.listJobs = async (req,res,next)=>{
+  try {
+    const jobs = await mdb.job.find().populate('projectId').populate('locationId').sort({ createdAt:-1 }).lean();
+    res.render(path.join('mongoose','jobRegList'),{ title:'Jobs', jobs });
+  }catch(err){ next(err); }
+};

--- a/mongoose/controllers/weeklyAttendanceController.js
+++ b/mongoose/controllers/weeklyAttendanceController.js
@@ -2,6 +2,7 @@ const moment = require('moment-timezone');
 const path = require('path');
 const attendanceService = require('../../services/mongoose/attendanceServicesMongoose');
 const taxService = require('../../services/taxService');
+const mdb = require('../../services/mongoose/mongooseDatabaseService');
 
 exports.getWeeklyAttendance = async (req,res,next)=>{
   try {
@@ -26,6 +27,11 @@ exports.getWeeklyAttendance = async (req,res,next)=>{
     const nextYear = requestedWeekNumber===totalWeeksInYear?year+1:year;
     const { attendanceRecords, employeeCount, subcontractorCount, allEmployees, allSubcontractors, paidReceipts } = await attendanceService.getAttendanceForWeek(payrollWeekStart,endDate);
     const { groupedAttendance, totalEmployeeHours, totalEmployeePay, totalSubcontractorPay, daysOfWeek } = attendanceService.groupAttendanceByPerson(attendanceRecords,payrollWeekStart,endDate,allEmployees,allSubcontractors,paidReceipts);
+    const activeJobs = await mdb.job.find({
+      startDate: { $lte: endDate.toDate() },
+      $or: [{ endDate: null }, { endDate: { $gte: payrollWeekStart.toDate() } }],
+      status: { $ne: "archived" }
+    }).populate("projectId").populate("locationId").lean();
     res.render(path.join('mongoose','weeklyAttendance'),{
       moment,
       groupedAttendance,
@@ -41,7 +47,8 @@ exports.getWeeklyAttendance = async (req,res,next)=>{
       totalEmployeeHours,
       totalSubcontractorPay,
       currentTab:'weekly',
-      daysOfWeek
+      daysOfWeek,
+      activeJobs
     });
   }catch(err){
     next(err);

--- a/mongoose/routes/jobRegistration.js
+++ b/mongoose/routes/jobRegistration.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const authService = require('../../services/authService');
+const ctrl = require('../controllers/jobsController');
+
+router.get('/job/register', authService.ensureRole(), ctrl.renderJobForm);
+router.post('/job/register', authService.ensureRole(), ctrl.registerJob);
+router.get('/jobs', authService.ensureRole(), ctrl.listJobs);
+
+module.exports = router;

--- a/mongoose/views/mongoose/jobRegList.ejs
+++ b/mongoose/views/mongoose/jobRegList.ejs
@@ -1,0 +1,27 @@
+<div class="container my-5">
+    <h1 class="text-center mb-4">Jobs</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Ref</th>
+                <th>Project</th>
+                <th>Location</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <% jobs.forEach(j => { %>
+                <tr>
+                    <td><%= j.jobRef %></td>
+                    <td><%= j.projectId ? (j.projectId.Name || j.projectId.Reference) : '' %></td>
+                    <td><%= j.locationId ? (j.locationId.name || j.locationId.address) : '' %></td>
+                    <td><%= j.startDate ? slimDateTime(j.startDate) : '' %></td>
+                    <td><%= j.endDate ? slimDateTime(j.endDate) : '' %></td>
+                    <td><%= j.status %></td>
+                </tr>
+            <% }) %>
+        </tbody>
+    </table>
+</div>

--- a/mongoose/views/mongoose/jobRegistration.ejs
+++ b/mongoose/views/mongoose/jobRegistration.ejs
@@ -1,0 +1,70 @@
+<div class="container my-5">
+    <h1 class="text-center mb-4">Job Registration</h1>
+    <form action="/job/register" method="POST" class="mb-5">
+        <div class="mb-3">
+            <label for="jobRef" class="form-label">Job Reference</label>
+            <input id="jobRef" name="jobRef" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="quoteRef" class="form-label">Quote Reference</label>
+            <input id="quoteRef" name="quoteRef" class="form-control">
+        </div>
+        <div class="mb-3">
+            <label for="projectId" class="form-label">Project</label>
+            <select id="projectId" name="projectId" class="form-select">
+                <option value="">Select Project</option>
+                <% projects.forEach(p => { %>
+                    <option value="<%= p._id %>"><%= p.Name || p.Reference %></option>
+                <% }) %>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="locationId" class="form-label">Location</label>
+            <select id="locationId" name="locationId" class="form-select">
+                <option value="">Select Location</option>
+                <% locations.forEach(l => { %>
+                    <option value="<%= l._id %>"><%= l.name || l.address %></option>
+                <% }) %>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="startDate" class="form-label">Start Date</label>
+            <input type="date" id="startDate" name="startDate" class="form-control">
+        </div>
+        <div class="mb-3">
+            <label for="endDate" class="form-label">End Date</label>
+            <input type="date" id="endDate" name="endDate" class="form-control">
+        </div>
+        <div class="mb-3">
+            <label for="description" class="form-label">Description</label>
+            <textarea id="description" name="description" rows="3" class="form-control"></textarea>
+        </div>
+        <button class="btn btn-hcs-green" type="submit">Save Job</button>
+    </form>
+
+    <h2 class="text-center mb-3">Current Jobs</h2>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Ref</th>
+                <th>Project</th>
+                <th>Location</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <% jobs.forEach(j => { %>
+                <tr>
+                    <td><%= j.jobRef %></td>
+                    <td><%= j.projectId ? (j.projectId.Name || j.projectId.Reference) : '' %></td>
+                    <td><%= j.locationId ? (j.locationId.name || j.locationId.address) : '' %></td>
+                    <td><%= j.startDate ? slimDateTime(j.startDate) : '' %></td>
+                    <td><%= j.endDate ? slimDateTime(j.endDate) : '' %></td>
+                    <td><%= j.status %></td>
+                </tr>
+            <% }) %>
+        </tbody>
+    </table>
+</div>

--- a/mongoose/views/mongoose/weeklyAttendance.ejs
+++ b/mongoose/views/mongoose/weeklyAttendance.ejs
@@ -56,6 +56,25 @@
             </div>
         </div>
 
+        <% if (activeJobs && activeJobs.length > 0) { %>
+        <h3 class="mt-5 mb-3">Scheduled Jobs</h3>
+        <ul class="list-group mb-5">
+            <% activeJobs.forEach(job => { %>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>
+                        <%= job.jobRef %>
+                        <% if (job.projectId) { %>
+                            (<%= job.projectId.Name || job.projectId.Reference %>)
+                        <% } %>
+                    </span>
+                    <% if (job.locationId) { %>
+                        <span class="badge text-bg-secondary"><%= job.locationId.name || job.locationId.address %></span>
+                    <% } %>
+                </li>
+            <% }) %>
+        </ul>
+        <% } %>
+
         <% 
             const employeeEntries = Object.entries(groupedAttendance).filter(([_, v]) => v.type === 'employee');
             const subcontractorEntries = Object.entries(groupedAttendance).filter(([_, v]) => v.type === 'subcontractor');


### PR DESCRIPTION
## Summary
- implement `job` mongoose model
- add controller and routes for job registration
- provide views for creating and listing jobs
- display scheduled jobs on the weekly attendance page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852c66074f4832ab7571e35044d7e01