### PR TITLE
Add task notifications with job scheduling

### DIFF
--- a/models/mongoose/job.js
+++ b/models/mongoose/job.js
@@ -7,12 +7,21 @@ const jobSchema = new mongoose.Schema({
   quoteRef: { type: String },
   projectId: { type: mongoose.Schema.Types.ObjectId, ref: 'project' },
   locationId: { type: mongoose.Schema.Types.ObjectId, ref: 'location' },
+  employeeId: { type: mongoose.Schema.Types.ObjectId, ref: 'employee', default: null },
+  supplierId: { type: mongoose.Schema.Types.ObjectId, ref: 'supplier', default: null },
   description: String,
   startDate: Date,
   endDate: Date,
   status: { type: String, enum: ['scheduled','active','completed','archived'], default: 'scheduled' }
 }, {
   timestamps: true
+});
+
+jobSchema.pre('validate', function (next) {
+  if (this.employeeId && this.supplierId) {
+    return next(new Error('Job cannot reference both employee and supplier.'));
+  }
+  next();
 });
 
 module.exports = mongoose.model('job', jobSchema);

--- a/models/mongoose/task.js
+++ b/models/mongoose/task.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const taskSchema = new mongoose.Schema({
+  uuid: { type: String, unique: true, required: true, default: uuidv4 },
+  title: { type: String, required: true },
+  description: { type: String },
+  dueDate: { type: Date },
+  recurrence: { type: String, enum: ['none', 'daily', 'weekly', 'monthly'], default: 'none' },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'user', required: true },
+  jobId: { type: mongoose.Schema.Types.ObjectId, ref: 'job', default: null },
+  completed: { type: Boolean, default: false }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('task', taskSchema);

--- a/mongoose/controllers/indexController.js
+++ b/mongoose/controllers/indexController.js
@@ -1,9 +1,19 @@
 const path = require('path');
 
-exports.renderIndex = (req, res, next) => {
-    res.render('index', {
-        title: 'Home',
-    });
+exports.renderIndex = async (req, res, next) => {
+    try {
+        let tasks = [];
+        if (req.user) {
+            const taskService = require('../../services/mongoose/taskService');
+            tasks = await taskService.getPendingTasksForUser(req.user._id);
+        }
+        res.render('index', {
+            title: 'Home',
+            tasks
+        });
+    } catch (err) {
+        next(err);
+    }
 };
 
 exports.renderConstructionIndustryScheme = (req, res, next) => {

--- a/mongoose/controllers/jobsController.js
+++ b/mongoose/controllers/jobsController.js
@@ -5,11 +5,15 @@ exports.renderJobForm = async (req,res,next)=>{
   try {
     const projects = await mdb.project.find({ Status: 1 }).sort({ Date1: -1 }).lean();
     const locations = await mdb.location.find().sort({ name: 1 }).lean();
+    const employees = await mdb.employee.find().sort({ name: 1 }).lean();
+    const suppliers = await mdb.supplier.find().sort({ Name: 1 }).lean();
     const jobs = await mdb.job.find().populate('projectId').populate('locationId').sort({ createdAt:-1 }).lean();
     res.render(path.join('mongoose','jobRegistration'),{
       title:'Job Registration',
       projects,
       locations,
+      employees,
+      suppliers,
       jobs
     });
   } catch(err){ next(err); }
@@ -17,18 +21,42 @@ exports.renderJobForm = async (req,res,next)=>{
 
 exports.registerJob = async (req,res,next)=>{
   try {
-    const { jobRef, quoteRef, projectId, locationId, description, startDate, endDate } = req.body;
+    const { jobRef, quoteRef, projectId, locationId, description, startDate, endDate, employeeId, supplierId } = req.body;
     const job = new mdb.job({
       jobRef,
       quoteRef: quoteRef || null,
       projectId: projectId || null,
       locationId: locationId || null,
+      employeeId: employeeId || null,
+      supplierId: supplierId || null,
       description,
       startDate: startDate || null,
       endDate: endDate || null,
       status: 'scheduled'
     });
     await job.save();
+
+    try {
+      const user = employeeId
+        ? await mdb.user.findOne({ employeeId })
+        : supplierId
+          ? await mdb.user.findOne({ subcontractorId: supplierId })
+          : null;
+      if (user) {
+        const taskService = require('../../services/mongoose/taskService');
+        await taskService.createTask({
+          title: `Job Scheduled: ${jobRef}`,
+          description: description || '',
+          userId: user._id,
+          jobId: job._id,
+          dueDate: startDate || null,
+          recurrence: 'none'
+        });
+      }
+    } catch (err) {
+      // non-fatal
+    }
+
     req.flash('success','Job registered');
     res.redirect('/job/register');
   }catch(err){ next(err); }

--- a/mongoose/views/mongoose/jobRegistration.ejs
+++ b/mongoose/views/mongoose/jobRegistration.ejs
@@ -28,6 +28,24 @@
             </select>
         </div>
         <div class="mb-3">
+            <label for="employeeId" class="form-label">Assign Employee</label>
+            <select id="employeeId" name="employeeId" class="form-select">
+                <option value="">Select Employee</option>
+                <% employees.forEach(e => { %>
+                    <option value="<%= e._id %>"><%= e.name %></option>
+                <% }) %>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="supplierId" class="form-label">Assign Supplier</label>
+            <select id="supplierId" name="supplierId" class="form-select">
+                <option value="">Select Supplier</option>
+                <% suppliers.forEach(s => { %>
+                    <option value="<%= s._id %>"><%= s.Name %></option>
+                <% }) %>
+            </select>
+        </div>
+        <div class="mb-3">
             <label for="startDate" class="form-label">Start Date</label>
             <input type="date" id="startDate" name="startDate" class="form-control">
         </div>

--- a/services/mongoose/taskService.js
+++ b/services/mongoose/taskService.js
@@ -1,0 +1,39 @@
+const mdb = require('./mongooseDatabaseService');
+
+async function createTask({ title, description, userId, jobId = null, dueDate = null, recurrence = 'none' }) {
+  const task = new mdb.task({ title, description, userId, jobId, dueDate, recurrence });
+  await task.save();
+  return task;
+}
+
+function advanceDate(date, recurrence) {
+  const next = new Date(date);
+  if (recurrence === 'daily') next.setDate(next.getDate() + 1);
+  else if (recurrence === 'weekly') next.setDate(next.getDate() + 7);
+  else if (recurrence === 'monthly') next.setMonth(next.getMonth() + 1);
+  return next;
+}
+
+async function getPendingTasksForUser(userId) {
+  if (!userId) return [];
+  const tasks = await mdb.task.find({ userId, completed: false }).sort({ dueDate: 1 });
+  const now = new Date();
+
+  for (const task of tasks) {
+    if (task.recurrence !== 'none' && task.dueDate && task.dueDate < now) {
+      let next = new Date(task.dueDate);
+      while (next < now) {
+        next = advanceDate(next, task.recurrence);
+      }
+      task.dueDate = next;
+      await task.save();
+    }
+  }
+
+  return tasks.map(t => t.toObject());
+}
+
+module.exports = {
+  createTask,
+  getPendingTasksForUser,
+};

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,6 +14,22 @@
     <% } %>
 
     <% if (isAuthenticated) { %>
+    <% if (tasks && tasks.length) { %>
+    <div class="card mb-3">
+      <div class="card-header">Your Tasks</div>
+      <ul class="list-group list-group-flush">
+        <% tasks.forEach(t => { %>
+        <li class="list-group-item">
+          <strong><%= t.title %></strong>
+          <% if (t.dueDate) { %>
+            <span class="text-muted"> - due <%= slimDateTime(t.dueDate) %></span>
+          <% } %>
+          <div><%= t.description %></div>
+        </li>
+        <% }) %>
+      </ul>
+    </div>
+    <% } %>
     <!-- Actions Section -->
     <div class="row row-cols-1 row-cols-md-3 g-4 mt-2">
       <% if (permissions.createInvoice) { %>


### PR DESCRIPTION
## Summary
- add Task schema and task service
- expand Job schema with employee/supplier references and validation
- create tasks when jobs are scheduled
- display tasks on index page for logged-in users
- enhance job registration form to assign employees or suppliers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852c961f2a8832a9b57baf1d3abdc5b