### PR TITLE
Add job registration links and listing

### DIFF
--- a/mongoose/controllers/jobsController.js
+++ b/mongoose/controllers/jobsController.js
@@ -37,6 +37,6 @@ exports.registerJob = async (req,res,next)=>{
 exports.listJobs = async (req,res,next)=>{
   try {
     const jobs = await mdb.job.find().populate('projectId').populate('locationId').sort({ createdAt:-1 }).lean();
-    res.render(path.join('mongoose','jobRegList'),{ title:'Jobs', jobs });
+    res.render(path.join('mongoose','jobs'),{ title:'Jobs', jobs });
   }catch(err){ next(err); }
 };

--- a/mongoose/views/mongoose/create.ejs
+++ b/mongoose/views/mongoose/create.ejs
@@ -29,6 +29,15 @@
           </div>
         </div>
       </div>
+      <div class="col">
+        <div class="card h-100 d-flex flex-column">
+          <div class="card-body">
+            <h5 class="card-header-pills">Job</h5>
+            <p class="card-text">Register a new job.</p>
+            <a href="/job/register" class="btn btn-hcs-green mt-auto">Job Register</a>
+          </div>
+        </div>
+      </div>
       <% if (isAdmin) { %>
       <div class="col">
         <div class="card h-100 d-flex flex-column">

--- a/mongoose/views/mongoose/jobs.ejs
+++ b/mongoose/views/mongoose/jobs.ejs
@@ -1,0 +1,27 @@
+<div class="container my-5">
+    <h1 class="text-center mb-4">Jobs</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Ref</th>
+                <th>Project</th>
+                <th>Location</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <% jobs.forEach(j => { %>
+                <tr>
+                    <td><%= j.jobRef %></td>
+                    <td><%= j.projectId ? (j.projectId.Name || j.projectId.Reference) : '' %></td>
+                    <td><%= j.locationId ? (j.locationId.name || j.locationId.address) : '' %></td>
+                    <td><%= j.startDate ? slimDateTime(j.startDate) : '' %></td>
+                    <td><%= j.endDate ? slimDateTime(j.endDate) : '' %></td>
+                    <td><%= j.status %></td>
+                </tr>
+            <% }) %>
+        </tbody>
+    </table>
+</div>

--- a/mongoose/views/mongoose/management.ejs
+++ b/mongoose/views/mongoose/management.ejs
@@ -23,6 +23,15 @@
       <div class="col">
         <div class="card h-100 d-flex flex-column">
           <div class="card-body">
+            <h5 class="card-header-pills">Jobs</h5>
+            <p class="card-text">Register and review jobs.</p>
+            <a href="/job/register" class="btn btn-hcs-green mt-auto">Job Register</a>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card h-100 d-flex flex-column">
+          <div class="card-body">
             <h5 class="card-header-pills">Weekly Attendance</h5>
             <p class="card-text">View weekly attendance summaries.</p>
             <a href="/attendance/weekly" class="btn btn-hcs-green mt-auto">Weekly Attendance</a>

--- a/views/partials/navigation.ejs
+++ b/views/partials/navigation.ejs
@@ -22,7 +22,8 @@
       </button>
       <div class="collapse" id="mgmtMenu">
         <ul class="btn-toggle-nav list-unstyled fw-normal small ps-3">
-          <li><a href="/dashboard/KFproject" class="nav-link">Job Reg</a></li>
+          <li><a href="/job/register" class="nav-link">Job Register</a></li>
+          <li><a href="/jobs" class="nav-link">Jobs</a></li>
           <li><a href="/attendance/weekly" class="nav-link">Weekly Attendance</a></li>
         </ul>
       </div>
@@ -70,7 +71,7 @@
           <li><a href="/dashboard/KFinvoice" class="nav-link">Invoices</a></li>
           <li><a href="/dashboard/KFquote" class="nav-link">Quotes</a></li>
           <li><a href="/dashboard/KFreceipt" class="nav-link">Purchases</a></li>
-          <li><a href="/dashboard/KFproject" class="nav-link">Jobs</a></li>
+          <li><a href="/projects" class="nav-link">Projects</a></li>
           <li><a href="/dashboard/CIS" class="nav-link">CIS</a></li>
           <li><a href="/kashflow/monthly/returns/form" class="nav-link">Monthly Returns</a></li>
         </ul>
@@ -87,6 +88,7 @@
           <li><a href="/attendance/create" class="nav-link">Attendance</a></li>
           <li><a href="/employee/create" class="nav-link">Employee</a></li>
           <li><a href="/location/create" class="nav-link">Location</a></li>
+          <li><a href="/job/register" class="nav-link">Job</a></li>
           <% if (isAdmin) { %>
           <li><a href="/user/create" class="nav-link">User</a></li>
           <% } %>


### PR DESCRIPTION
## Summary
- connect new job registration pages to navigation
- link job features from management and create pages
- render jobs list using new EJS template

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852c98e2c48832a80f0c1a669bacac0