### PR TITLE
Add task creation view and routes

### DIFF
--- a/mongoose/controllers/tasksController.js
+++ b/mongoose/controllers/tasksController.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const taskService = require('../../services/mongoose/taskService');
+
+exports.renderCreateTaskForm = (req, res) => {
+  res.render(path.join('mongoose', 'createTask'), {
+    title: 'Create Task'
+  });
+};
+
+exports.createTask = async (req, res, next) => {
+  try {
+    const { title, description, dueDate, recurrence } = req.body;
+    const userId = req.user._id;
+    await taskService.createTask({
+      title,
+      description,
+      userId,
+      dueDate: dueDate || null,
+      recurrence: recurrence || 'none'
+    });
+    req.flash('success', 'Task created');
+    res.redirect('/');
+  } catch (err) {
+    next(err);
+  }
+};

--- a/mongoose/routes/tasks.js
+++ b/mongoose/routes/tasks.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const authService = require('../../services/authService');
+const ctrl = require('../controllers/tasksController');
+
+router.get('/task/create', authService.ensureRole(), ctrl.renderCreateTaskForm);
+router.post('/task/create', authService.ensureRole(), ctrl.createTask);
+
+module.exports = router;

--- a/mongoose/views/mongoose/create.ejs
+++ b/mongoose/views/mongoose/create.ejs
@@ -38,6 +38,15 @@
           </div>
         </div>
       </div>
+      <div class="col">
+        <div class="card h-100 d-flex flex-column">
+          <div class="card-body">
+            <h5 class="card-header-pills">Task</h5>
+            <p class="card-text">Create a new task.</p>
+            <a href="/task/create" class="btn btn-hcs-green mt-auto">Task</a>
+          </div>
+        </div>
+      </div>
       <% if (isAdmin) { %>
       <div class="col">
         <div class="card h-100 d-flex flex-column">

--- a/mongoose/views/mongoose/createTask.ejs
+++ b/mongoose/views/mongoose/createTask.ejs
@@ -1,0 +1,41 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <h1 class="display-5 fw-bold text-center">Create Task</h1>
+    <div class="container-fluid text-center">
+      <form action="/task/create" method="POST" class="needs-validation">
+        <div class="row mb-3">
+          <label for="title" class="col-sm-3 col-form-label">Title</label>
+          <div class="col-sm-9">
+            <input type="text" id="title" name="title" class="form-control" required>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <label for="description" class="col-sm-3 col-form-label">Description</label>
+          <div class="col-sm-9">
+            <textarea id="description" name="description" rows="3" class="form-control"></textarea>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <label for="dueDate" class="col-sm-3 col-form-label">Due Date</label>
+          <div class="col-sm-9">
+            <input type="date" id="dueDate" name="dueDate" class="form-control">
+          </div>
+        </div>
+        <div class="row mb-3">
+          <label for="recurrence" class="col-sm-3 col-form-label">Recurrence</label>
+          <div class="col-sm-9">
+            <select id="recurrence" name="recurrence" class="form-select">
+              <option value="none">None</option>
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+            </select>
+          </div>
+        </div>
+        <div class="d-grid">
+          <button type="submit" class="btn btn-hcs-green">Create Task</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- allow admins to create tasks
- link to task creation from the create menu
- implement controller and route for tasks
- add createTask.ejs form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852db70d55c832a852ea63d14a7f530