### PR TITLE
Add controller and service unit tests

### DIFF
--- a/test/services.test.js
+++ b/test/services.test.js
@@ -1,0 +1,67 @@
+const { expect } = require('chai');
+const path = require('path');
+
+describe('validationService.validateInvoiceData', () => {
+  const { validateInvoiceData } = require('../services/validationService');
+
+  it('returns cleaned data when valid', () => {
+    const data = {
+      invoiceNumber: 'INV1',
+      kashflowNumber: 'KF1',
+      invoiceDate: '2024-01-01',
+      remittanceDate: '2024-02-01',
+      labourCost: 100,
+      materialCost: 50,
+      submissionDate: '0000-00-00 00:00:00',
+    };
+    const result = validateInvoiceData({ ...data });
+    expect(result.remittanceDate).to.equal('2024-02-01');
+    expect(result.submissionDate).to.equal(null);
+  });
+
+  it('throws when invoiceNumber missing', () => {
+    const data = {
+      invoiceNumber: '',
+      kashflowNumber: 'KF1',
+      invoiceDate: '2024-01-01',
+      labourCost: 10,
+      materialCost: 5,
+    };
+    expect(() => validateInvoiceData(data)).to.throw('invoiceNumber');
+  });
+});
+
+describe('encryptionService encrypt/decrypt', () => {
+  before(() => {
+    process.env.ENCRYPTION_KEY = 'test-secret';
+    // clear require cache so service reads env
+    delete require.cache[require.resolve('../services/encryptionService')];
+  });
+  const encryptionService = require('../services/encryptionService');
+
+  it('round trips text correctly', () => {
+    const encrypted = encryptionService.encrypt('hello');
+    const decrypted = encryptionService.decrypt(encrypted);
+    expect(decrypted).to.equal('hello');
+  });
+
+  it('throws on invalid encrypted text', () => {
+    expect(() => encryptionService.decrypt('badtext')).to.throw();
+  });
+});
+
+describe('taxService.calculateTaxYearAndMonth', () => {
+  const { calculateTaxYearAndMonth } = require('../services/taxService');
+
+  it('calculates correct tax year before April 6th', () => {
+    const { taxYear, taxMonth } = calculateTaxYearAndMonth('2023-04-05T00:00:00Z');
+    expect(taxYear).to.equal(2022);
+    expect(taxMonth).to.equal(12);
+  });
+
+  it('calculates start of new tax year', () => {
+    const { taxYear, taxMonth } = calculateTaxYearAndMonth('2023-04-06T00:00:00Z');
+    expect(taxYear).to.equal(2023);
+    expect(taxMonth).to.equal(1);
+  });
+});

--- a/test/user.controller.test.js
+++ b/test/user.controller.test.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const request = require('supertest');
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+
+let userStub = null;
+
+const stubs = {
+  '../../services/sequelizeDatabaseService': {
+    Users: {
+      findByPk: async () => userStub,
+    },
+  },
+  '../../services/authService': {
+    ensureRole: () => (req, res, next) => next(),
+  },
+  '../../services/loggerService': { error: () => {}, info: () => {} },
+  '../../models/sequelize/user': { rolePermissions: {} },
+};
+
+const router = proxyquire('../controllers/forms/user.js', stubs);
+
+function createApp() {
+  const app = express();
+  app.use((req, res, next) => {
+    req.flash = () => {};
+    res.render = (view, options = {}) => {
+      res.json({ view, ...options });
+    };
+    next();
+  });
+  app.use(router);
+  app.use((err, req, res, next) => {
+    res.status(500).send(err.message);
+  });
+  return app;
+}
+
+describe('user controller', () => {
+  it('renders update form when user exists', async () => {
+    userStub = { id: 'abc', permissions: '{}' };
+    const res = await request(createApp()).get('/update/abc').expect(200);
+    expect(res.body.view).to.include('updateUser');
+    expect(res.body.user.id).to.equal('abc');
+  });
+
+  it('redirects to /users when user missing', async () => {
+    userStub = null;
+    const res = await request(createApp()).get('/update/missing').expect(302);
+    expect(res.headers.location).to.equal('/users');
+  });
+});


### PR DESCRIPTION
## Summary
- add service unit tests for validation, encryption and tax helpers
- add user controller unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541a4960b4832ab9960f10c08100cd