### PR TITLE
Fix Playwright config

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,7 +5,7 @@ const config = {
     headless: true,
     browserName: 'chromium',
     launchOptions: {
-      executablePath: '/usr/bin/chromium-browser'
+      executablePath: '/root/.cache/ms-playwright/chromium-1179/chrome-linux/chrome'
     }
   }
 };


### PR DESCRIPTION
## Summary
- use Playwright's bundled Chromium instead of the snap wrapper

## Testing
- `npm test` *(fails: browserType.launch: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68541e9aa460832aab2a5ab1e7adb0c6