### PR TITLE
Remove permissions feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,6 @@ const main = async () => {
       res.locals.firstName = req.user && req.user.username
         ? req.user.username.split('.')[0].replace(/^\w/, c => c.toUpperCase())
         : null;
-      res.locals.permissions = req.user && req.user.permissions || {};
       res.locals.package = packageJson.version;
       res.locals.slimDateTime = require('./services/dateService').slimDateTime;
       res.locals.formatCurrency = require('./services/currencyService').formatCurrency;
@@ -168,7 +167,6 @@ main();
 
 
 // TODO:
-// - Remove all permissions checks from routes and logic.
 // - Allow for Subcontractor users to see their own data.
 // - Allow for Client users to see their own data.
 // - Allow for Employee users to see their own data.

--- a/migrateToMongoose.js
+++ b/migrateToMongoose.js
@@ -11,7 +11,6 @@ const transformUser = async (record) => {
     email: record.email.toLowerCase(),
     password: record.password,
     role: record.role,
-    permissions: record.permissions || {},
     totpSecret: record.totpSecret || null,
     totpEnabled: record.totpEnabled || false,
     createdAt: record.createdAt,

--- a/mongoose/controllers/loginController.js
+++ b/mongoose/controllers/loginController.js
@@ -57,7 +57,6 @@ exports.loginUser = async (req, res) => {
       username: user.username,
       email: user.email,
       role: user.role,
-      permissions: user.permissions || {},
       loginTime: new Date().toISOString(),
       ip,
       userAgent: {

--- a/mongoose/controllers/twoFAController.js
+++ b/mongoose/controllers/twoFAController.js
@@ -53,7 +53,6 @@ exports.verify2FA = async (req, res) => {
       username: user.username,
       email: user.email,
       role: user.role,
-      permissions: user.permissions || {},
       loginTime: new Date().toISOString(),
       ip,
       userAgent: {

--- a/mongoose/models/mongoose/user.js
+++ b/mongoose/models/mongoose/user.js
@@ -28,10 +28,6 @@ const userSchema = new Schema({
         enum: ['subcontractor', 'employee', 'accountant', 'hmrc', 'admin', 'client'],
         default: 'subcontractor'
     },
-    permissions: {
-        type: Object,
-        default: {}
-    },
     subcontractorId: {
         type: Schema.Types.ObjectId,
         ref: 'supplier',
@@ -62,15 +58,10 @@ const userSchema = new Schema({
     toObject: { getters: true }
 });
 
-// Hash password and assign permissions before save
+// Hash password before save
 userSchema.pre('save', async function (next) {
     if (this.isModified('password')) {
         this.password = await bcrypt.hash(this.password, 10);
-    }
-
-    // Assign permissions if new or role changed or permissions empty
-    if (this.isNew || this.isModified('role') || !this.permissions || Object.keys(this.permissions).length === 0) {
-        this.permissions = getPermissionsForRole(this.role);
     }
 
     // Ensure only one of the foreign keys is set

--- a/mongoose/views/mongoose/index.ejs
+++ b/mongoose/views/mongoose/index.ejs
@@ -57,7 +57,7 @@
           <div class="card h-100 d-flex flex-column">
             <div class="card-body">
               <h5 class="card-header-pills">Manage Users</h5>
-              <p class="card-text">Create and manage user accounts with role-based permissions.</p>
+              <p class="card-text">Create and manage user accounts.</p>
               <a href="/users" class="btn btn-hcs-green mt-auto">Manage Users</a>
             </div>
           </div>
@@ -78,7 +78,7 @@
 
     <% if (isAuthenticated) { %>
     <p class="text-center text-muted mt-4">
-      If you are missing any permissions, please email: 
+      For additional access, email:
       <a href="mailto:<%= contactEmail %>" class="hcs-green-text"><%= contactEmail %></a>.
     </p>
     <% } %>

--- a/test/twoFA.test.js
+++ b/test/twoFA.test.js
@@ -29,7 +29,6 @@ describe('twoFAController.verify2FA', () => {
       username: 'name',
       email: 'e@e.com',
       role: 'admin',
-      permissions: {},
       totpSecret: 'enc'
     });
     decryptStub = () => 'secret';
@@ -37,7 +36,7 @@ describe('twoFAController.verify2FA', () => {
 
     const req = {
       body: { totpToken: '123' },
-      session: { userPending2FA: { uuid: 'abc', username: 'name', role: 'admin', permissions: {} } },
+      session: { userPending2FA: { uuid: 'abc', username: 'name', role: 'admin' } },
       useragent: {},
       ip: '1.2.3.4'
     };
@@ -59,7 +58,6 @@ describe('twoFAController.verify2FA', () => {
       username: 'name',
       email: 'e@e.com',
       role: 'admin',
-      permissions: {},
       totpSecret: 'enc'
     });
     decryptStub = () => 'secret';

--- a/test/user.controller.test.js
+++ b/test/user.controller.test.js
@@ -34,7 +34,7 @@ function createApp() {
 
 describe.skip('user controller', () => {
   it('renders update form when user exists', async () => {
-    userStub = { id: 'abc', permissions: '{}' };
+    userStub = { id: 'abc' };
     const res = await request(createApp()).get('/user/update/abc').expect(200);
     expect(res.body.view).to.include('updateUser');
     expect(res.body.user.id).to.equal('abc');


### PR DESCRIPTION
## Summary
- drop `permissions` from user model and migration script
- remove permissions from login and 2FA controllers
- update middleware locals and index page text
- adjust related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb695e8e8832aa3243de104b41180