### PR TITLE
Fix account sessions query error

### DIFF
--- a/mongoose/models/mongoose/session.js
+++ b/mongoose/models/mongoose/session.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const sessionSchema = new Schema({
+  _id: { type: String },
+  expires: { type: Date, required: true },
+  session: { type: Schema.Types.Mixed, required: true }
+}, { collection: 'sessions', minimize: false });
+
+module.exports = mongoose.model('session', sessionSchema);


### PR DESCRIPTION
## Summary
- define a `session` model in Mongoose so settings controller can query active sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628f985650832a80714fc31cce73f4