### PR TITLE
Add missing view templates

### DIFF
--- a/mongoose/views/attendance/viewAttendance.ejs
+++ b/mongoose/views/attendance/viewAttendance.ejs
@@ -1,0 +1,21 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Attendance Details</h1>
+      <div class="card">
+        <div class="card-body">
+          <ul class="list-group">
+            <li class="list-group-item"><strong>Date:</strong> <%= slimDateTime(attendance.date) %></li>
+            <li class="list-group-item"><strong>Location:</strong> <%= attendance.locationId?.name || 'N/A' %></li>
+            <li class="list-group-item"><strong>Project:</strong> <%= attendance.projectId?.Name || 'N/A' %></li>
+            <li class="list-group-item"><strong>Employee:</strong> <%= attendance.employeeId?.name || 'N/A' %></li>
+            <li class="list-group-item"><strong>Subcontractor:</strong> <%= attendance.subcontractorId?.Name || 'N/A' %></li>
+            <li class="list-group-item"><strong>Type:</strong> <%= attendance.type %></li>
+            <li class="list-group-item"><strong>Hours Worked:</strong> <%= attendance.hoursWorked ?? 'N/A' %></li>
+            <li class="list-group-item"><strong>Day Rate:</strong> <%= attendance.dayRate ?? 'N/A' %></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/createAssignment.ejs
+++ b/mongoose/views/mongoose/createAssignment.ejs
@@ -1,0 +1,9 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Create Assignment</h1>
+      <p>This form will allow you to create a new assignment.</p>
+      <!-- TODO: add form fields -->
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/createContract.ejs
+++ b/mongoose/views/mongoose/createContract.ejs
@@ -1,0 +1,9 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Create Contract</h1>
+      <p>This form will allow you to create a new contract.</p>
+      <!-- TODO: add form fields -->
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/updateAssignement.ejs
+++ b/mongoose/views/mongoose/updateAssignement.ejs
@@ -1,0 +1,9 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Update Assignment</h1>
+      <p>Update assignment details here.</p>
+      <!-- TODO: add form fields -->
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/updateContract.ejs
+++ b/mongoose/views/mongoose/updateContract.ejs
@@ -1,0 +1,9 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Update Contract</h1>
+      <p>Update contract details here.</p>
+      <!-- TODO: add form fields -->
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/viewAssignment.ejs
+++ b/mongoose/views/mongoose/viewAssignment.ejs
@@ -1,0 +1,21 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Assignment Details</h1>
+      <div class="card">
+        <div class="card-body">
+          <ul class="list-group">
+            <li class="list-group-item"><strong>Title:</strong> <%= assignment.title %></li>
+            <li class="list-group-item"><strong>Description:</strong> <%= assignment.description || 'N/A' %></li>
+            <li class="list-group-item"><strong>Week Start:</strong> <%= slimDateTime(assignment.weekStart) %></li>
+            <li class="list-group-item"><strong>Estimated Hours:</strong> <%= assignment.estimatedHours ?? 'N/A' %></li>
+            <li class="list-group-item"><strong>Status:</strong> <%= assignment.status %></li>
+            <li class="list-group-item"><strong>Contract:</strong> <a href="/contract/<%= assignment.contractId._id %>"><%= assignment.contractId.title %></a></li>
+            <li class="list-group-item"><strong>Employees:</strong> <%= assignment.assignedEmployees.map(e => e.name).join(', ') || 'N/A' %></li>
+            <li class="list-group-item"><strong>Subcontractors:</strong> <%= assignment.assignedSubcontractors.map(s => s.Name).join(', ') || 'N/A' %></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/mongoose/views/mongoose/viewContract.ejs
+++ b/mongoose/views/mongoose/viewContract.ejs
@@ -1,0 +1,22 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Contract Details</h1>
+      <div class="card">
+        <div class="card-body">
+          <ul class="list-group">
+            <li class="list-group-item"><strong>Title:</strong> <%= contract.title %></li>
+            <li class="list-group-item"><strong>Location:</strong> <%= contract.location %></li>
+            <li class="list-group-item"><strong>Start Date:</strong> <%= slimDateTime(contract.startDate) %></li>
+            <li class="list-group-item"><strong>End Date:</strong> <%= slimDateTime(contract.endDate) %></li>
+            <li class="list-group-item"><strong>Status:</strong> <%= contract.status %></li>
+            <li class="list-group-item"><strong>Notes:</strong> <%= contract.notes || 'N/A' %></li>
+            <% if (contract.quoteId) { %>
+            <li class="list-group-item"><strong>Quote:</strong> <a href="/quote/read/<%= contract.quoteId.uuid %>"><%= contract.quoteId.title %></a></li>
+            <% } %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/mongoose/views/user/2fa.ejs
+++ b/mongoose/views/user/2fa.ejs
@@ -1,0 +1,16 @@
+<div class="container py-4">
+  <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold text-center">Two-Factor Authentication</h1>
+      <form action="/user/2fa" method="POST">
+        <div class="form-floating mb-3">
+          <input type="text" id="totpToken" name="totpToken" class="form-control" required>
+          <label for="totpToken" class="form-label">Authentication Code</label>
+        </div>
+        <div class="d-grid gap-2 mt-4">
+          <button class="btn btn-hcs-green" type="submit"><i class="bi bi-shield-lock"></i> Verify</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add actual 2FA view under `mongoose/views/user`
- add attendance details view for `/attendance/read/:id`
- provide contract and assignment detail pages
- populate placeholder templates for contract/assignment forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862ac697f3c832aa1f137dec9e9cdd2