### PR TITLE
fix(pwa): never cache a redirected or cross-origin response

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -89,8 +89,13 @@ self.addEventListener('fetch', (event) => {
         const cached = await cache.match(request);
         const network = fetch(request)
           .then((response) => {
-            // Opaque/error responses are not worth persisting.
-            if (response && response.ok) cache.put(request, response.clone());
+            // Only persist a direct, successful, same-origin hit. `redirected` is the
+            // important one: an asset behind authentication redirects to the login page,
+            // which answers 200 with HTML — caching that would pin the login page under
+            // a .js or .css URL and break the app for the rest of the cache's life.
+            if (response && response.ok && !response.redirected && response.type === 'basic') {
+              cache.put(request, response.clone());
+            }
             return response;
           })
           .catch(() => cached);

--- a/tests/pwaAssets.test.js
+++ b/tests/pwaAssets.test.js
@@ -71,6 +71,14 @@ describe('PWA wiring', () => {
     );
   });
 
+  it('never caches a redirected response', () => {
+    // An auth-gated asset redirects to the login page, which answers 200 with HTML.
+    // Caching that would pin login HTML under a .js/.css URL.
+    const sw = read('public/service-worker.js');
+    assert.match(sw, /!response\.redirected/);
+    assert.match(sw, /response\.type === 'basic'/);
+  });
+
   it('precaches every asset the offline page embeds', () => {
     // Opportunistic caching is not enough: an offline device that never happened to
     // fetch the logo would render the fallback page with a broken image.


### PR DESCRIPTION
Follow-up to #62, which merged before this landed.

The service worker's static-asset branch cached on `response.ok` alone. An asset sitting behind authentication does not fail — it **redirects to the login page, which answers 200 with HTML**. That response would have been stored under the `.js` or `.css` URL that triggered it, serving login markup as a script for the rest of that cache version's life.

Now only a direct, successful, same-origin response is persisted:

```js
if (response && response.ok && !response.redirected && response.type === 'basic') {
  cache.put(request, response.clone());
}
```

This is latent on `master` today rather than actively broken, because `/resources/*` is currently unauthenticated in practice (see below). It becomes load-bearing the moment that is fixed, which is why it is worth having in place first.

## Context

While reviewing what the worker caches, I found that `services/authService.js` lists `/resources/` in `PUBLIC_PREFIXES`, so `isPublicPath()` returns true for it and the `ensureAuthenticated` guard on the `/resources` static mount never actually gates anything. That is being handled separately — it is an auth issue, not a service-worker one.

## Testing

- `npm test` → 721/722. The single failure (`emailNotifications.test.js`) is pre-existing on `master` and environmental; it needs `UNSUBSCRIBE_SECRET`/`SESSION_SECRET`.
- Added a regression assertion in `tests/pwaAssets.test.js` covering both conditions.