### PR TITLE
fix(deps): pin quill back to 2.0.2 (GHSA-v3m3-f69x-jf25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.17.1] - 2026-07-30
+
+### Security
+- **Pinned `quill` back to 2.0.2** ([GHSA-v3m3-f69x-jf25](https://github.com/advisories/GHSA-v3m3-f69x-jf25) — XSS via the HTML export feature, affects exactly 2.0.3, no patched release). 6.16.0 vendored Quill from the CDN and pinned 2.0.3, a version bump the app never asked for; 2.0.2 is what it had been loading all along and is unaffected. Practical exposure was low — the advisory targets `getSemanticHTML()`, which this app does not call — but there is no reason to carry it. `npm audit` is now clean.
+
 ## [6.17.0] - 2026-07-30
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.17.0",
+  "version": "6.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.17.0",
+      "version": "6.17.1",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",
@@ -53,7 +53,7 @@
         "moment-timezone": "^0.6.2",
         "nodemon": "^3.1.4",
         "postcss": "^8.4.47",
-        "quill": "2.0.3",
+        "quill": "2.0.2",
         "tailwindcss": "^3.4.13"
       },
       "engines": {
@@ -3298,9 +3298,9 @@
       "license": "MIT"
     },
     "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
+      "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.17.0",
+  "version": "6.17.1",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",
   "main": "app.js",
@@ -75,7 +75,7 @@
     "moment-timezone": "^0.6.2",
     "nodemon": "^3.1.4",
     "postcss": "^8.4.47",
-    "quill": "2.0.3",
+    "quill": "2.0.2",
     "tailwindcss": "^3.4.13"
   },
   "overrides": {


### PR DESCRIPTION
Closes the Dependabot alert opened against #62.

## What happened

[GHSA-v3m3-f69x-jf25](https://github.com/advisories/GHSA-v3m3-f69x-jf25) — XSS via Quill's HTML export feature. It affects **exactly 2.0.3**, and there is no patched release; npm's own remediation is to move to 2.0.2.

**This was my mistake in #62.** Quill was previously loaded from jsDelivr at `quill@2.0.2`. When vendoring it I pinned `2.0.3` — bumping the version rather than pinning what the app was actually running. 2.0.2 is unaffected, so this reverts to the version that was already in production.

Worth noting the alert only appeared *because* of #62: as a CDN `<script>` tag Quill was invisible to Dependabot. Vendoring put it in `package-lock.json` where it can be tracked. The visibility is the point — it just caught my own bump first.

## Actual exposure

Low. The advisory targets `getSemanticHTML()`, and this app never calls it — verified by grep across the views and JS. Quill is used only as the policy editor, initialised in `layout.ejs` behind the `quillEditor` flag. No reason to carry the alert regardless.

## Changes

- `quill` pinned `2.0.3` → `2.0.2` (exact, matching how the other vendored libraries are pinned)
- `npm audit` → **0 vulnerabilities**
- Version bumped to 6.16.1

`public/vendor/` is generated by `scripts/vendor-assets.js` at build time and is gitignored, so no vendored artefact needed re-committing — CI rebuilds it from the lockfile. Confirmed 2.0.2 ships `dist/quill.js`, the path the vendor script uses.

## Testing

`npm test` → 720/721. The single failure (`emailNotifications.test.js`) is pre-existing on `master` and environmental — it needs `UNSUBSCRIBE_SECRET`/`SESSION_SECRET`. The existing `tests/pwaAssets.test.js` assertion that vendored libraries are pinned to an exact version still passes.