### PR TITLE
fix(logging): interpolate %s — printf-style logging never worked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.20.2] - 2026-08-04
+
+Restores printf-style logging, which has never worked.
+
+### Fixed
+- **Every `logger.info('… %s', value)` call logged the placeholder verbatim and discarded the argument.** winston only interpolates `%s`/`%d` when `format.splat()` is in the format chain, and `services/loggerService.js` combined `timestamp()` with `json()` and nothing else. So the 12 printf-style call sites across the app — 9 of them in `ssoController.js` — have been writing `invalid credentials for "%s"` to the log with no username attached, for as long as the logger has existed. This is not cosmetic: a failed hcs-sync SSO login recorded *which endpoint* rejected the attempt but never *whose account*, so a locked-out user could only be identified by scanning the users collection for a non-zero `loginAttempts`. `splat()` now sits between `timestamp()` and `json()`, which fixes all 12 sites at once. It has to precede any format that consumes `message` — putting it after `json()` would silently do nothing, which is the failure mode being fixed.
+
+### Security
+- **`logger.sanitize` had no callers.** It strips newlines and control characters to stop a user-controlled value forging a second log line, and it was written for exactly this interpolation — but since interpolation never happened, nothing was ever injectable and the helper was never wired up. Turning `splat()` on makes those arguments land in the log for the first time, so the one attacker-controlled site is now sanitised: `ssoController.js` logs the `username` straight off the SSO request body. The other 11 sites interpolate an `err.message` or a `user.username` already loaded from the database and are left as they are.
+
+### Added
+- `tests/loggerService.test.js` — 7 cases. Interpolation of a single `%s`, of mixed `%d`/`%s`, and the no-placeholder-with-meta case that must stay untouched; then sanitising: newline stripping against a forged-log-line payload, control characters and the length cap, nullish input, and reachability via the default export. The two interpolation cases fail against the unfixed logger; the no-placeholder case passes either way, since it is guarding against a regression from `splat()` rather than the bug itself.
+
 ## [6.20.1] - 2026-08-04
 
 ### Changed

--- a/mongoose/controllers/ssoController.js
+++ b/mongoose/controllers/ssoController.js
@@ -316,7 +316,9 @@ export const issueTokenForSync = async (req, res) => {
   }
 
   if (!authOk) {
-    logger.info("[sso] /api/sso/token: invalid credentials for \"%s\"", username);
+    // `username` is straight off the request body — sanitize before it reaches
+    // the log line. Every other %s here interpolates a trusted value.
+    logger.info("[sso] /api/sso/token: invalid credentials for \"%s\"", logger.sanitize(username));
     await recordFailedAttempt();
     return res.status(401).json({ error: "Invalid credentials" });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.20.1",
+  "version": "6.20.2",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",
   "main": "app.js",

--- a/services/loggerService.js
+++ b/services/loggerService.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname as _esmDirname } from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = _esmDirname(__filename);
-const { combine, timestamp, printf, colorize, json } = format;
+const { combine, timestamp, printf, colorize, json, splat } = format;
 
 let io = null;
 
@@ -58,7 +58,10 @@ const isTest = process.env.NODE_ENV === 'test';
 
 const logger = createLogger({
   level: "debug",
-  format: combine(timestamp({ format: "DD-MM-YYYY HH:mm:ss" }), json()),
+  // splat() must precede any format that consumes `message`, otherwise
+  // printf-style calls such as logger.info('... "%s"', username) log the
+  // placeholder verbatim and silently drop the argument.
+  format: combine(timestamp({ format: "DD-MM-YYYY HH:mm:ss" }), splat(), json()),
   transports: [
     new transports.Console({
       format: combine(

--- a/tests/loggerService.test.js
+++ b/tests/loggerService.test.js
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import Transport from 'winston-transport';
+import logger, { sanitize } from '../services/loggerService.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Transport that records every info object it receives. */
+class CaptureTransport extends Transport {
+  constructor() {
+    super();
+    this.records = [];
+  }
+
+  log(info, callback) {
+    this.records.push(info);
+    callback();
+  }
+}
+
+/**
+ * Run `fn` with a capture transport attached to the shared logger and return
+ * the messages it saw. The logger-level format (which is where splat() lives)
+ * runs before any transport, so `info.message` here is post-interpolation.
+ */
+function capture(fn) {
+  const capture = new CaptureTransport();
+  logger.add(capture);
+  try {
+    fn();
+  } finally {
+    logger.remove(capture);
+  }
+  return capture.records.map((r) => r.message);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('loggerService printf-style interpolation', () => {
+  it('interpolates a single %s argument', () => {
+    const [message] = capture(() => {
+      logger.info('[sso] /api/sso/token: invalid credentials for "%s"', 'jack.oldfield');
+    });
+
+    assert.equal(message, '[sso] /api/sso/token: invalid credentials for "jack.oldfield"');
+    assert.ok(!message.includes('%s'), 'placeholder must not survive into the message');
+  });
+
+  it('interpolates multiple placeholders of mixed type', () => {
+    const [message] = capture(() => {
+      logger.warn('[login] Unexpected status %d from %s', 503, 'hcs-app');
+    });
+
+    assert.equal(message, '[login] Unexpected status 503 from hcs-app');
+  });
+
+  it('leaves a message without placeholders untouched when meta is passed', () => {
+    const [message] = capture(() => {
+      logger.info('plain message', { userId: 42 });
+    });
+
+    assert.equal(message, 'plain message');
+  });
+});
+
+describe('loggerService sanitize', () => {
+  it('strips newlines so a forged log line cannot be injected', () => {
+    const forged = 'attacker"\n01-01-2026 info: [sso] issued token for user "admin';
+    const [message] = capture(() => {
+      logger.info('[sso] invalid credentials for "%s"', sanitize(forged));
+    });
+
+    assert.ok(!message.includes('\n'), 'newlines must not reach the log message');
+    assert.ok(!message.includes('\r'), 'carriage returns must not reach the log message');
+    assert.equal(message.split('\n').length, 1, 'must remain a single line');
+  });
+
+  it('strips control characters and truncates to the length cap', () => {
+    assert.equal(sanitize('a\tb\x00c'), 'a b c');
+    assert.equal(sanitize('x'.repeat(500)).length, 200);
+    assert.equal(sanitize('x'.repeat(500), 10).length, 10);
+  });
+
+  it('renders nullish input as a literal rather than throwing', () => {
+    assert.equal(sanitize(null), 'null');
+    assert.equal(sanitize(undefined), 'null');
+  });
+
+  it('is reachable as a property of the default export', () => {
+    assert.equal(typeof logger.sanitize, 'function');
+    assert.equal(logger.sanitize('a\nb'), 'a b');
+  });
+});


### PR DESCRIPTION
## What

winston only substitutes `%s`/`%d` when `format.splat()` is in the format chain. `services/loggerService.js` combined `timestamp()` with `json()` and nothing else, so **all 12 printf-style call sites in the app** have been logging the placeholder verbatim and dropping the argument — for as long as the logger has existed.

9 of those 12 are in `ssoController.js`.

## How it surfaced

A user could not log in to the hcs-sync dashboard. hcs-app logged the rejection four times:

```
[sso] /api/sso/token: invalid credentials for "%s"
```

No username. Identifying the account meant scanning the users collection for a non-zero `loginAttempts` instead of reading it off the log line.

## The fix

`splat()` goes between `timestamp()` and `json()` — one line, fixes all 12 sites. It has to precede any format that consumes `message`; placed after `json()` it silently does nothing, which is the failure mode being fixed.

## Security note

`logger.sanitize` — which strips newlines so a user-controlled value cannot forge a second log line — **had no callers anywhere in the codebase**. It was written for exactly this interpolation, but since interpolation never happened, nothing was ever injectable.

Turning `splat()` on makes those arguments land in the log for the first time, so the one attacker-controlled site is now sanitised: `ssoController.js` logs the `username` straight off the SSO request body. The other 11 interpolate an `err.message` or a `user.username` already read from the database.

## Tests

`tests/loggerService.test.js`, 7 cases: single `%s`, mixed `%d`/`%s`, the no-placeholder-with-meta case that must stay untouched, then sanitising — newline stripping against a forged-log-line payload, control characters, the length cap, nullish input, and reachability via the default export.

Verified non-vacuous: the 2 interpolation cases fail against the unfixed logger.

Full suite: **1041/1041 passing**.