### PR TITLE
chore: pin hcs-schemas 3.0.0 (follow-up to #69)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,8 +84,8 @@
       }
     },
     "node_modules/@cappytech/hcs-schemas": {
-      "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/CappyTech/hcs-schemas.git#ee58acc9d181a3e1773d38653ff750272dc15a73",
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/CappyTech/hcs-schemas.git#ea340f3dd3c2f54a7802804605421973d77d0385",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=20"


### PR DESCRIPTION
#69 merged before its lockfile update landed, so `master` carries the code change but still pins hcs-schemas **2.1.0**. CI installs with `npm ci`, so the published `:latest` image is built against the schema that still declares `{ Id: 1 }, unique: true`.

**Do not deploy the current `:latest`.** `mongoose/models/mongoose/REST/bankTransaction.js` builds its indexes straight from the schema and `autoIndex` defaults on, so this image would try to recreate the unique `Id_1` index that hcs-sync 0.11.0's migration removes — fighting the migration rather than degrading quietly.

Lockfile only — pins `ea340f3`, the schemas 3.0.0 merge commit. Verified the resolved package exports the composite index:

```
[{"fields":{"AccountId":1,"Id":1},"options":{"unique":true,"sparse":true}},{"fields":{"Id":1}}]
```

Full suite passes against the real 3.0.0.
