### PR TITLE
6.21.1 — fail the build on a stale hcs-schemas pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.21.1] - 2026-08-06
+
+### Added
+- **The build fails when the `hcs-schemas` pin is stale.** `npm ci` installs the commit pinned in `package-lock.json`, so merging hcs-schemas to its default branch does not update this repo. That step has now been missed twice, both times publishing an image built against the wrong schema — most recently 6.21.0 itself, pinned to schemas 2.1.0 whose `bankTransaction` still declared the unique `Id` index that release exists to replace. Deploying it would have recreated the index hcs-sync 0.11.0's migration removes.
+
+  `scripts/check-schemas-version.js` compares the installed version against `requiredSchemasVersion` in package.json and fails with the exact fix command. It runs in the **Dockerfile builder stage**, not the workflow: CI has no `npm ci` step of its own, and this way it guards the exact image being published, before it can reach `:latest`. Verified by building with a deliberately stale requirement — exit 1, no image.
+
+### Changed
+- `bank-stranded-lines` logs when it acts. The scheduler keeps `lastResult` for `/admin/jobs` but logs nothing on success, and this job soft-deletes rows and rewrites match lines; that belongs somewhere more durable than a UI panel. Silent on a no-op, which is its normal state.
+
+### Note
+`npm test` is commented out in `.github/workflows/ci.yml` and there is no install step, so this repo's 1,076 tests **do not run in CI**. Unchanged here, but worth fixing.
+
 ## [6.21.0] - 2026-08-05
 
 Requires **hcs-schemas 3.0.0** and pairs with **hcs-sync 0.11.0**. A bank line is now identified by *(account, KashFlow Id)* rather than Id alone, throughout `/bank`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
 
+# Fails the build when the hcs-schemas commit pinned in package-lock.json is
+# older than this code needs. Placed here, in the builder, so a bad pin never
+# reaches a published image: the box deploys from :latest. `npm ci` installs the
+# pinned commit, so merging hcs-schemas alone does not update this repo - a step
+# missed twice, both times publishing an image built against the wrong schema.
+COPY scripts/check-schemas-version.js ./scripts/
+RUN node scripts/check-schemas-version.js
+
 COPY assets ./assets
 COPY tailwind.config.js tailwind.safelist.js postcss.config.js ./
 COPY mongoose/views ./mongoose/views

--- a/mongoose/services/bankStrandedLineService.js
+++ b/mongoose/services/bankStrandedLineService.js
@@ -1,4 +1,5 @@
 import mdb from './mongooseDatabaseService.js';
+import logger from '../../services/loggerService.js';
 import { bankLineKey, LIVE_BANK_LINE } from './bankLinkService.js';
 
 /**
@@ -121,6 +122,16 @@ export async function reconcileStrandedLines({ dryRun = false } = {}) {
     }
 
     stats.retired += 1;
+  }
+
+  // Logged only when it acts. The scheduler keeps `lastResult` for /admin/jobs
+  // but logs nothing on success, and this job soft-deletes rows and moves match
+  // lines — that should leave a trace somewhere durable, not only in a UI panel.
+  if (stats.retired > 0 && !dryRun) {
+    logger.info(
+      `[bank-stranded-lines] retired ${stats.retired} stranded bank line(s); `
+      + `moved ${stats.matchLinesMoved} match line(s) and ${stats.statementLinesMoved} statement line(s)`,
+    );
   }
 
   return stats;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.21.0",
+  "version": "6.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.21.0",
+      "version": "6.21.1",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hcs-app",
   "version": "6.21.0",
+  "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",
   "main": "app.js",
@@ -85,3 +86,4 @@
     "minimatch": ">=10.2.1"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.21.0",
+  "version": "6.21.1",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",
@@ -86,4 +86,3 @@
     "minimatch": ">=10.2.1"
   }
 }
-

--- a/scripts/check-schemas-version.js
+++ b/scripts/check-schemas-version.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Fail the build when the installed @cappytech/hcs-schemas is older than this
+ * package's code requires.
+ *
+ * `@cappytech/hcs-schemas` is a git dependency (`github:CappyTech/hcs-schemas`).
+ * That *looks* like a branch tip, but npm pins the resolved commit in
+ * package-lock.json and CI installs with `npm ci`, so merging schemas to its
+ * default branch changes nothing here. Updating the consumer is a separate,
+ * easily-forgotten step: `npm install github:CappyTech/hcs-schemas` plus a
+ * lockfile commit.
+ *
+ * It has been forgotten twice, and neither time was caught before an image was
+ * published:
+ *
+ *   - hcs-sync 0.10.0 shipped built against schemas 2.0.0, without the
+ *     bankReconciliation entity. It survived only because the consumer guards
+ *     its use of new entities.
+ *   - hcs-app 6.21.0 and hcs-sync 0.11.0 were merged before their lockfile
+ *     updates landed, publishing images pinned to schemas 2.1.0 — which still
+ *     declared bankTransaction's unique index on `Id` alone, the exact index
+ *     that release exists to replace. Deploying it would have recreated the
+ *     index the migration removes.
+ *
+ * Documenting the three-step deploy did not prevent either. A failing build
+ * does. Bump `requiredSchemasVersion` in package.json in the same commit that
+ * starts depending on new schema behaviour.
+ */
+import { readFile } from 'node:fs/promises';
+
+const read = async (path) => JSON.parse(await readFile(new URL(path, import.meta.url), 'utf8'));
+
+/** Numeric compare of dotted versions. Prerelease tags are not used here. */
+function isAtLeast(actual, required) {
+  const parse = (v) => String(v).split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const [a, b] = [parse(actual), parse(required)];
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    if ((a[i] || 0) !== (b[i] || 0)) return (a[i] || 0) > (b[i] || 0);
+  }
+  return true;
+}
+
+const pkg = await read('../package.json');
+const required = pkg.requiredSchemasVersion;
+if (!required) {
+  console.error('[schemas-check] package.json is missing "requiredSchemasVersion".');
+  process.exit(1);
+}
+
+let installed;
+try {
+  installed = (await read('../node_modules/@cappytech/hcs-schemas/package.json')).version;
+} catch {
+  console.error('[schemas-check] @cappytech/hcs-schemas is not installed. Run npm ci first.');
+  process.exit(1);
+}
+
+if (!isAtLeast(installed, required)) {
+  console.error(
+    `[schemas-check] installed @cappytech/hcs-schemas is ${installed}, but this package requires >= ${required}.\n`
+    + '\n'
+    + 'The lockfile pins a commit, so merging hcs-schemas does not update this repo.\n'
+    + 'Fix with:\n'
+    + '\n'
+    + '    npm install github:CappyTech/hcs-schemas\n'
+    + '    git commit package-lock.json -m "chore: pin hcs-schemas"\n',
+  );
+  process.exit(1);
+}
+
+console.log(`[schemas-check] @cappytech/hcs-schemas ${installed} satisfies >= ${required}`);


### PR DESCRIPTION
Follow-up to the (account, id) re-key.

**The lockfile trap caught us twice.** `@cappytech/hcs-schemas` is a git dependency: it looks like a branch tip, but npm pins the resolved commit in `package-lock.json` and CI installs with `npm ci`, so merging schemas changes nothing downstream. hcs-sync 0.10.0 shipped against schemas 2.0.0; then **6.21.0 itself** was merged before its lockfile update landed, publishing an image pinned to schemas 2.1.0 — whose `bankTransaction` still declared the unique `Id` index that release exists to replace. Deploying it would have recreated the index hcs-sync 0.11.0's migration removes. Documenting the three-step deploy prevented neither.

`scripts/check-schemas-version.js` compares the installed version against `requiredSchemasVersion` and fails with the exact fix command. It runs in the **Dockerfile builder stage**, not the workflow — this repo's CI has no `npm ci` step of its own, and the builder guards the exact image being published before it can reach `:latest`. Verified by building against a deliberately stale requirement: exit 1, no image produced.

Also: `bank-stranded-lines` now logs when it acts. The scheduler keeps `lastResult` for `/admin/jobs` but logs nothing on success, and that job soft-deletes rows and rewrites match lines.

**Worth knowing:** `npm test` is commented out in `.github/workflows/ci.yml` and there is no install step, so this repo's 1,076 tests do not run in CI at all. Not changed here — flagging it.
