### PR TITLE
6.21.2 — stop the test runner silently discarding tests, and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: npm
+
+      - run: npm ci --no-audit --no-fund
 
       - name: Security audit (prod deps)
         timeout-minutes: 3
         run: npm audit --omit=dev --audit-level=high
 
-      # - run: npm test
+      # Runs before the image is built: the box deploys from :latest, so a
+      # failing suite must not reach that tag. Previously commented out, with no
+      # install step at all, so none of these tests had ever run in CI.
+      - name: Test
+        timeout-minutes: 10
+        run: npm test
 
       - name: Derive tags
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.21.2] - 2026-08-06
+
+### Fixed
+- **The test runner was silently discarding up to 49 tests per run.** `scripts/run-tests.js` passed `--test-force-exit`, which brings the process down as soon as the runner believes it is finished — racing the slower test files still reporting their results. Those tests were **dropped, not failed**, so the run reported success either way. The visible symptom was a test count wandering between 1,037 and 1,086 across runs, which read like harmless flakiness; it meant a regression in the affected files could never surface. `tests/bankViews.test.js` (39 tests) was the usual casualty, and is perfectly deterministic in isolation.
+
+  The flag is normally a workaround for a leaked handle keeping the process alive. There is no such handle here — without it the suite exits 0 on its own in ~1.6s, and five consecutive runs report exactly **1086 passed**. Verified on Node 20 and Node 24 (CI's version).
+
+### Changed
+- **CI now installs dependencies and runs the tests.** `npm test` was commented out in `.github/workflows/ci.yml` and there was no `npm ci` step at all, so this repo's tests had **never run in CI** — every image was published on the strength of a local run. Both steps now run before the image is built, because the box deploys from `:latest` and a failing suite must not reach that tag.
+
+  Enabling this depended on the fix above: enforcing a suite whose own count moved by 49 between runs would have produced exactly the kind of unexplained red build that gets commented out again.
+
 ## [6.21.1] - 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.21.1",
+  "version": "6.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.21.1",
+      "version": "6.21.2",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.21.1",
+  "version": "6.21.2",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -25,7 +25,19 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-const result = spawnSync(process.execPath, ['--test', '--test-force-exit', '--experimental-test-module-mocks', ...files], {
+// NB: no `--test-force-exit`. It forces the process down as soon as the runner
+// believes it is finished, which races the slower test files still reporting
+// their results — they were silently dropped from the run, not failed. The
+// visible symptom was a test count that wandered between 1,037 and 1,086
+// across runs while always reporting success, so up to 49 tests could vanish
+// without a trace and a regression in them would never surface. `tests/bankViews.test.js`
+// (39 tests) was the usual casualty; it is deterministic in isolation.
+//
+// The flag is normally a workaround for a leaked handle keeping the process
+// alive. There isn't one here: without it the suite exits 0 on its own in
+// ~1.6s. If a hang ever appears, find the open handle rather than reinstating
+// this — the cure hid 5% of the suite.
+const result = spawnSync(process.execPath, ['--test', '--experimental-test-module-mocks', ...files], {
   cwd: path.join(__dirname, '..'),
   stdio: 'inherit',
   env: { ...process.env, NODE_ENV: 'test' },


### PR DESCRIPTION
Two problems that compounded each other: a suite that quietly dropped tests, and a CI that never ran it.

### The runner was discarding up to 49 tests per run

`scripts/run-tests.js` passed `--test-force-exit`. That brings the process down as soon as the runner believes it is finished, racing the slower test files still reporting their results. Those tests were **dropped, not failed** — the run reported success either way.

The symptom was a test count wandering between **1,037 and 1,086** across runs, which reads like harmless flakiness. It is not: a regression in the affected files could never surface, and `tests/bankViews.test.js` (39 tests — the entire `/bank` view layer, which this week's re-key touched heavily) was the usual casualty. It is perfectly deterministic in isolation.

`--test-force-exit` is normally a workaround for a leaked handle keeping the process alive. There is no such handle here — without it the suite exits 0 on its own in ~1.6s. Five consecutive runs: **1086 passed** every time. Verified on Node 20 and on Node 24 (CI's version, run in `node:24-alpine`): same 1086.

### CI never ran the tests

`npm test` was commented out and there was no `npm ci` step at all, so this repo's tests had **never run in CI** — every image has been published on the strength of somebody's local run. Both steps now run before the image is built, since the box deploys from `:latest`.

The ordering mattered: enforcing a suite whose own count moved by 49 between runs would have produced exactly the kind of unexplained red build that gets commented out again. Hence the runner fix first.
