### PR TITLE
fix: HMRC timezone header, dashboard role filtering, and IA re-filing (6.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.23.0] - 2026-08-07
+
+### Fixed
+- **`Gov-Client-Timezone` sent `UTC+697:00` to HMRC between 00:00 and 01:00 BST.** `_londonOffset()` formatted the current time in `Europe/London` and `UTC` using `'en-GB'` — `DD/MM/YYYY` — then fed both strings back to `new Date()`, which reads them as `MM/DD/YYYY`. Both sides misparsed *identically* for most of the day, so the subtraction came out right and the fault stayed invisible.
+
+  Between midnight and 01:00 BST the two zones fall on different dates. At 00:01 on 7 August, London formatted as `07/08/2026` (read as 8 July) and UTC as `06/08/2026` (read as 8 June) — 30 days apart, i.e. `UTC+697:00`, sent as a fraud-prevention header on any RTI submission made in that hour. Past the 12th of a month the same round-trip yields `Invalid Date` and `UTCNaN:NaN` instead.
+
+  Now asks `Intl` for the offset directly via `timeZoneName: 'longOffset'`. Verified across midsummer, midwinter, both DST transitions, the 00:xx window in each direction, and a day-of-month past 12. The existing test was correct all along — it simply had a one-hour-a-day window in which to catch this, and happened to run inside it.
+
+- **Dashboard tiles ignored role entirely.** `rbac.canAccess` returns `{ allowed, ownOnly }`; every consumer destructures `.allowed` except the two filters in `indexController`, which used the bare return value. An object is always truthy, so both filters passed for every role and every model — a department showed its whole tile list to anyone who could open it. Never a permission bypass, since the list and CRUD routes carry their own guards, but the dashboards advertised links that answer 403.
+
+- **Custom tiles are now filtered by the route they point at.** They were filtered by department alone, so any department wider than the pages inside it advertised 403s. Two were live: a subcontractor was shown *CIS Dashboard* and *Edit CIS Details*, and *Edit CIS Details* was also shown to accountant and hmrc despite being admin-only. The check derives from `routeAccess` rather than a per-tile role list, so it cannot drift from the guard it describes; external links and paths with no entry fall back to department membership, both meaning "routeAccess has no opinion".
+
+### Changed
+- **`routeAccess` now covers the ten `/overview/*` pages.** They were guarded only by `ensureRole*` in `overviewRoutes.js` with no entry in the registry that claims to be the single source of truth — so `matchRoutePattern` returned nothing and tiles pointing at them could not be role-filtered at all. Every entry mirrors the guard already on its route, so nothing gains or loses access. Deliberately not a blanket `/overview`: `/overview/finance` and `/overview/payroll` are wider than the other eight, and longest-prefix matching would have hidden that.
+
+- **Dashboard filing.** Users moves from HR to Admin — HR manages *employees*, this manages *login accounts*, and every route behind it was already `ensureRole:admin` while the landing page's own admin overview is captioned "Users, roles & 2FA". Attendances gains the Attendance department alongside Management. The duplicate `AdminSettings` tile is removed (byte-for-byte identical to `UserSettings`, same `/user/account` link), and Notification Settings is under User only — an admin's own password is not an admin tool. The Users list gains an **Auditor** tab for the role added in 6.22.0.
+
+  Holiday Overview, Holiday Requests and the `holidayRequest` list stay in **both** HR and Management: approving holiday is a management job and administering it is an HR job. A tile belongs wherever the work happens, so the same tool in two departments is the system working rather than duplication to tidy away.
+
+### Note
+Two gaps are now visible rather than fixed, both instances of permissions having been dropped down route by route from an originally admin-only default while the department gates stayed put:
+
+- Payroll is `admin, accountant`, but `/daily` and `/weekly` admit only `admin, employee, subcontractor` — so an accountant cannot open the attendance that running payroll needs. The tiles are hidden rather than 403ing; widening the route is an access decision.
+- Five department gates are narrower than the routes inside them (`maintenance`, `human-resources`, `management`, `payroll`, `finance`). `session` and `meta` are **not** among them: both carry `deny: ['c','r','u','d','l']` because they hold auth tokens, CSRF state and TOTP data, and are hidden on purpose.
+
 ## [6.22.0] - 2026-08-06
 
 ### Added

--- a/mongoose/config/dashboardTilesConfig.js
+++ b/mongoose/config/dashboardTilesConfig.js
@@ -48,13 +48,10 @@ export default {
         department: ['admin'],
         buttonClass: 'bg-amber-700 hover:bg-amber-800'
     },
-    AdminSettings: {
-        title: 'Settings',
-        description: 'Manage your account settings, password, and preferences.',
-        link: '/user/account',
-        department: ['admin'],
-        buttonClass: 'bg-green-700 hover:bg-green-800'
-    },
+    // AdminSettings removed: it was byte-for-byte UserSettings (same title,
+    // same /user/account link) filed under admin as well. An admin's own
+    // password is a personal setting, and it is already one tile away under
+    // User — putting it beside Maintenance Mode implied it was an admin tool.
     ConnectionSettings: {
         title: 'External Connections',
         description: 'Configure KashFlow API, SMTP email, and Paperless-ngx credentials.',
@@ -117,7 +114,9 @@ export default {
         title: 'Notification Settings',
         description: 'Choose which emails you receive, preview them, and control admin contact.',
         link: '/user/account/settings/notifications',
-        department: ['user', 'admin'],
+        // Personal preference, so it belongs under User only. Same reasoning
+        // as the removed AdminSettings tile.
+        department: ['user'],
         buttonClass: 'bg-green-700 hover:bg-green-800'
     },
     Logout: {
@@ -321,14 +320,16 @@ export default {
         title: 'Holiday Overview',
         description: 'Manage holiday accrual, requests and approvals.',
         link: '/overview/holiday',
-        department: ['human-resources', 'management'],
+        // HR owns holidays. Management is also admin-only, so dropping it here
+        // takes the tile off a second dashboard without taking it from anyone.
+        department: ['human-resources'],
         buttonClass: 'bg-green-700 hover:bg-green-800'
     },
     HolidayRequests: {
         title: 'Holiday Requests',
         description: 'Review, approve and reject employee holiday requests.',
         link: '/holidayRequests',
-        department: ['human-resources', 'management'],
+        department: ['human-resources'],
         buttonClass: 'bg-green-700 hover:bg-green-800'
     }
 };

--- a/mongoose/config/dashboardTilesConfig.js
+++ b/mongoose/config/dashboardTilesConfig.js
@@ -320,16 +320,18 @@ export default {
         title: 'Holiday Overview',
         description: 'Manage holiday accrual, requests and approvals.',
         link: '/overview/holiday',
-        // HR owns holidays. Management is also admin-only, so dropping it here
-        // takes the tile off a second dashboard without taking it from anyone.
-        department: ['human-resources'],
+        // Listed in both on purpose: approving holiday is a management job and
+        // administering it is an HR job. A tile belongs wherever the work
+        // happens, so the same tool appearing in two departments is the system
+        // working, not duplication to be tidied away.
+        department: ['human-resources', 'management'],
         buttonClass: 'bg-green-700 hover:bg-green-800'
     },
     HolidayRequests: {
         title: 'Holiday Requests',
         description: 'Review, approve and reject employee holiday requests.',
         link: '/holidayRequests',
-        department: ['human-resources'],
+        department: ['human-resources', 'management'],
         buttonClass: 'bg-green-700 hover:bg-green-800'
     }
 };

--- a/mongoose/config/listControllerConfig.js
+++ b/mongoose/config/listControllerConfig.js
@@ -127,7 +127,10 @@ export default {
     fieldOrder: ['date', 'type', 'status', 'employeeId', 'subcontractorId', 'hoursWorked', 'overtimeHours', 'dayRate', 'payRate', 'locationId', 'projectId', 'notes'],
     sortField: 'date',
     sortOrder: -1,
-    department: ['management'],
+    // The eponymous department. Model tiles are role-filtered by
+    // rbac.canAccess(role, model, 'l'), so employees and subcontractors see
+    // this only to the extent their own 'l:own' grant allows.
+    department: ['attendance'],
     tabsby: 'type',
     tabsValues: [
       { value: 'all', label: 'All' },
@@ -957,7 +960,12 @@ export default {
     fieldOrder: ['username', 'email', 'emailVerified', 'role', 'employeeId', 'subcontractorId', 'clientId'],
     sortField: 'username',
     sortOrder: 1,
-    department: ['human-resources'],
+    // Admin, not HR. HR manages *employees*; this manages *login accounts* —
+    // the same people, but a different noun and a different audience. Every
+    // route behind it is already `ensureRole:admin`, and the landing page's
+    // own admin overview is captioned "Users, roles & 2FA", so filing it under
+    // HR was the only thing saying otherwise.
+    department: ['admin'],
     // Filter by role — useful for quickly seeing all admins, employees, subcontractors etc.
     tabsby: 'role',
     tabsValues: [
@@ -968,6 +976,9 @@ export default {
       { value: 'subcontractor', label: 'Subcontractor' },
       { value: 'client', label: 'Client' },
       { value: 'hmrc', label: 'HMRC' },
+      // External read-only accountant. Without a tab here the role exists and
+      // is assignable but its users are invisible on every tab except "All".
+      { value: 'auditor', label: 'Auditor' },
       { value: 'none', label: 'None' },
     ],
     labelOverrides: {
@@ -1052,7 +1063,10 @@ export default {
     ],
     sortField: 'startDate',
     sortOrder: -1,
-    department: ['human-resources', 'management'],
+    // HR owns holidays outright. Management showed the same list to the same
+    // audience (both departments are admin-only), so listing it twice split
+    // ownership without widening access to anyone.
+    department: ['human-resources'],
     labelOverrides: {
       employeeId: 'Employee',
       startDate: 'From',

--- a/mongoose/config/listControllerConfig.js
+++ b/mongoose/config/listControllerConfig.js
@@ -127,10 +127,11 @@ export default {
     fieldOrder: ['date', 'type', 'status', 'employeeId', 'subcontractorId', 'hoursWorked', 'overtimeHours', 'dayRate', 'payRate', 'locationId', 'projectId', 'notes'],
     sortField: 'date',
     sortOrder: -1,
-    // The eponymous department. Model tiles are role-filtered by
-    // rbac.canAccess(role, model, 'l'), so employees and subcontractors see
-    // this only to the extent their own 'l:own' grant allows.
-    department: ['attendance'],
+    // The eponymous department, plus management, which reviews it. Tiles are
+    // role-filtered by rbac.canAccess(...).allowed — note the `.allowed`: that
+    // filter was reading a truthy object and letting everything through until
+    // it was fixed alongside this.
+    department: ['attendance', 'management'],
     tabsby: 'type',
     tabsValues: [
       { value: 'all', label: 'All' },
@@ -1063,10 +1064,9 @@ export default {
     ],
     sortField: 'startDate',
     sortOrder: -1,
-    // HR owns holidays outright. Management showed the same list to the same
-    // audience (both departments are admin-only), so listing it twice split
-    // ownership without widening access to anyone.
-    department: ['human-resources'],
+    // Both: HR administers holiday, management approves it. Two workflows over
+    // one list, which is a reason to appear twice rather than a duplication.
+    department: ['human-resources', 'management'],
     labelOverrides: {
       employeeId: 'Employee',
       startDate: 'From',

--- a/mongoose/config/rolePermissionsConfig.js
+++ b/mongoose/config/rolePermissionsConfig.js
@@ -171,6 +171,29 @@ const routeAccess = {
   // routing, not merely by hidden buttons.
   '/accountant':          ['admin', 'accountant', 'auditor'],
 
+  // Overview (analytics) pages.
+  //
+  // These were guarded only by ensureRole* in overviewRoutes.js and had no
+  // entry here at all, which made routeAccess incomplete as a registry — and
+  // dashboard tiles pointing at them could not be role-filtered, because
+  // matchRoutePattern returned nothing to filter on.
+  //
+  // Every line below mirrors the guard already on the route, so nothing gains
+  // or loses access; the point is that the fact is now written down where the
+  // rest of the app can read it. '/overview' is deliberately NOT a blanket
+  // entry: '/overview/finance' and '/overview/payroll' are wider than the
+  // rest, and longest-prefix matching would hide that.
+  '/overview/admin':          ['admin'],
+  '/overview/documents':      ['admin'],
+  '/overview/finance':        ['admin', 'accountant'],
+  '/overview/fleet':          ['admin'],
+  '/overview/holiday':        ['admin'],
+  '/overview/human':          ['admin'],
+  '/overview/payroll':        ['admin', 'accountant'],
+  '/overview/policies':       ['admin'],
+  '/overview/projects':       ['admin'],
+  '/overview/subcontractors': ['admin', 'accountant', 'hmrc'],
+
   // Subcontractor administration
   '/subcontractor/assign':['admin'],
   '/supplier/change':     ['admin'],

--- a/mongoose/controllers/indexController.js
+++ b/mongoose/controllers/indexController.js
@@ -11,6 +11,32 @@ import { endOfToday, endOfWeek, endOfMonth } from 'date-fns';
 const denyGuard = (config, op) =>
   Array.isArray(config.deny) && config.deny.includes(op);
 
+/**
+ * May this role actually use the page a custom tile points at?
+ *
+ * Model tiles have always been role-filtered; custom tiles were filtered by
+ * department alone, so any department wider than the routes inside it
+ * advertised links that answer 403. That was live in two places: a
+ * subcontractor saw the CIS Dashboard and Assign Subcontractors tiles (both
+ * narrower than the CIS department), and an admin saw Submit Attendance, which
+ * only employees and subcontractors may open.
+ *
+ * The answer is derived from routeAccess rather than declared per tile, so it
+ * cannot drift out of step with the guard it describes. Two deliberate
+ * fallbacks to department membership, both meaning "routeAccess has no opinion":
+ * external links (nothing to match), and internal paths with no entry.
+ */
+const canUseTile = (tile, userRole) => {
+  if (userRole === 'admin') return true;
+  const link = String(tile?.link || '');
+  if (!link.startsWith('/')) return true; // external link
+
+  const pattern = rbac.matchRoutePattern(link);
+  if (!pattern) return true; // not a controlled route
+
+  return rbac.canAccessRoute(userRole, pattern);
+};
+
 // Helper: get all visible listable models for a department, filtered by role
 const getDashboardModels = (department, userRole) => {
   const standardModels = Object.entries(listConfig)
@@ -40,8 +66,8 @@ const getDashboardModels = (department, userRole) => {
       };
     });
 
-  const extraTiles = Object.values(customTiles).filter((tile) =>
-    tile.department?.includes(department),
+  const extraTiles = Object.values(customTiles).filter(
+    (tile) => tile.department?.includes(department) && canUseTile(tile, userRole),
   );
 
   return [...standardModels, ...extraTiles];

--- a/mongoose/controllers/indexController.js
+++ b/mongoose/controllers/indexController.js
@@ -18,7 +18,11 @@ const getDashboardModels = (department, userRole) => {
       ([model, config]) =>
         config?.department?.includes(department) &&
         !denyGuard(config, "l") &&
-        (userRole === "admin" || rbac.canAccess(userRole, model, "l")),
+        // .allowed, not the bare return value: canAccess returns
+        // { allowed, ownOnly }, and an object is always truthy — so this
+        // filter passed for every role and every model, showing a
+        // department's whole tile list to anyone who could open it.
+        (userRole === "admin" || rbac.canAccess(userRole, model, "l").allowed),
     )
     .map(([model, config]) => {
       const desc =
@@ -49,7 +53,10 @@ const getCreateModels = (userRole) => {
     .filter(
       ([model, config]) =>
         !denyGuard(config, "c") &&
-        (userRole === "admin" || rbac.canAccess(userRole, model, "c")),
+        // Same bug as getDashboardModels above. Currently masked because the
+        // 'create' department is admin-only and admin short-circuits, but it
+        // would open the moment that department is opened up.
+        (userRole === "admin" || rbac.canAccess(userRole, model, "c").allowed),
     )
     .map(([model, config]) => ({
       model,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.22.0",
+  "version": "6.23.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/services/hmrcRtiService.js
+++ b/services/hmrcRtiService.js
@@ -50,16 +50,36 @@ function _deriveDeviceId() {
 const SERVER_DEVICE_ID = _deriveDeviceId();
 
 // ── London UTC offset string (handles BST/GMT automatically) ─────────────────
+/**
+ * `Gov-Client-Timezone` for HMRC's fraud-prevention headers, e.g. "UTC+01:00".
+ *
+ * Asks Intl for the offset directly rather than reconstructing it by
+ * subtracting two formatted timestamps. The previous implementation formatted
+ * `now` in both zones with `en-GB` — which produces `DD/MM/YYYY` — and fed
+ * those strings back to `new Date()`, which reads them as `MM/DD/YYYY`.
+ *
+ * Both sides misparsed identically for most of the day, so the difference came
+ * out right and the bug stayed invisible. Between 00:00 and 01:00 BST the two
+ * zones fall on **different dates**: at 00:01 on 7 August, London formatted as
+ * `07/08/2026` (read as 8 July) and UTC as `06/08/2026` (read as 8 June) — 30
+ * days apart, giving `UTC+697:00`. HMRC would have received that as a
+ * fraud-prevention header on any RTI submission made in that hour. Past the
+ * 12th of a month the same round-trip yields `Invalid Date` and `UTCNaN:NaN`
+ * instead.
+ *
+ * `longOffset` returns "GMT" exactly (no numeric part) during GMT, which is
+ * why the no-match branch returns +00:00 rather than treating it as an error.
+ */
 function _londonOffset() {
-  const now = new Date();
-  const londonTime = new Date(now.toLocaleString('en-GB', { timeZone: 'Europe/London' }));
-  const utcTime    = new Date(now.toLocaleString('en-GB', { timeZone: 'UTC' }));
-  const diffMins   = Math.round((londonTime - utcTime) / 60000);
-  const sign       = diffMins >= 0 ? '+' : '-';
-  const abs        = Math.abs(diffMins);
-  const hh         = String(Math.floor(abs / 60)).padStart(2, '0');
-  const mm         = String(abs % 60).padStart(2, '0');
-  return `UTC${sign}${hh}:${mm}`;
+  const name = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/London',
+    timeZoneName: 'longOffset',
+  })
+    .formatToParts(new Date())
+    .find(p => p.type === 'timeZoneName')?.value || 'GMT';
+
+  const m = /^GMT([+-])(\d{2}):(\d{2})$/.exec(name);
+  return m ? `UTC${m[1]}${m[2]}:${m[3]}` : 'UTC+00:00';
 }
 
 /**

--- a/tests/dashboardRoleFilter.test.js
+++ b/tests/dashboardRoleFilter.test.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import rbac from '../mongoose/config/rolePermissionsConfig.js';
+
+/**
+ * `rbac.canAccess` returns `{ allowed, ownOnly }`, so using its return value as
+ * a bare boolean is *always true*. Every consumer destructures `.allowed`
+ * except, for a while, the two dashboard filters in indexController — which
+ * meant a department showed its whole tile list to any role that could open it.
+ *
+ * It never became a permission bypass, because the list and CRUD routes carry
+ * their own guards; it made the dashboards advertise links that answer 403.
+ * That is exactly the kind of fault that reappears, because the broken form
+ * reads perfectly naturally.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const indexControllerSrc = fs.readFileSync(
+  path.join(ROOT, 'mongoose/controllers/indexController.js'), 'utf8',
+);
+
+describe('dashboard tile role filtering', () => {
+  it('canAccess returns an object, so a bare call is always truthy', () => {
+    const denied = rbac.canAccess('auditor', 'invoice', 'l');
+    assert.equal(typeof denied, 'object');
+    assert.equal(denied.allowed, false);
+    // The trap, stated as an assertion: this is why `.allowed` is required.
+    assert.ok(denied, 'a denied result is still truthy as an object');
+  });
+
+  it('indexController never uses canAccess as a bare boolean', () => {
+    const calls = indexControllerSrc.match(/rbac\.canAccess\([^)]*\)(\.allowed)?/g) || [];
+    assert.ok(calls.length >= 2, `expected the dashboard filters, found ${calls.length}`);
+    for (const call of calls) {
+      assert.ok(
+        call.endsWith('.allowed'),
+        `"${call}" reads canAccess as a boolean; it returns { allowed, ownOnly }`,
+      );
+    }
+  });
+
+  it('a role with no model grants can list nothing', () => {
+    // The auditor role added in 6.22.0 has no roleModelAccess entry at all.
+    assert.deepEqual(rbac.getListableModels('auditor'), []);
+    for (const model of ['user', 'invoice', 'employee', 'vehicle', 'attendance']) {
+      assert.equal(
+        rbac.canAccess('auditor', model, 'l').allowed, false,
+        `auditor should not be able to list ${model}`,
+      );
+    }
+  });
+});

--- a/tests/dashboardRoleFilter.test.js
+++ b/tests/dashboardRoleFilter.test.js
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import rbac from '../mongoose/config/rolePermissionsConfig.js';
+import departmentsConfig from '../mongoose/config/departmentsConfig.js';
+import customTiles from '../mongoose/config/dashboardTilesConfig.js';
 
 /**
  * `rbac.canAccess` returns `{ allowed, ownOnly }`, so using its return value as
@@ -41,6 +43,51 @@ describe('dashboard tile role filtering', () => {
         `"${call}" reads canAccess as a boolean; it returns { allowed, ownOnly }`,
       );
     }
+  });
+
+  it('no custom tile advertises a route its department cannot open', () => {
+    // The invariant: for every department, every custom tile on it, and every
+    // role that may open that department, the tile's target must be reachable.
+    // Two of these were live — a subcontractor was shown the CIS Dashboard and
+    // Assign Subcontractors, and an admin-only department showed Submit
+    // Attendance, which admins may not open.
+    const offenders = [];
+
+    for (const [slug, dept] of Object.entries(departmentsConfig)) {
+      for (const tile of Object.values(customTiles)) {
+        if (!tile.department?.includes(slug)) continue;
+
+        const link = String(tile.link || '');
+        if (!link.startsWith('/')) continue;              // external
+        const pattern = rbac.matchRoutePattern(link);
+        if (!pattern) continue;                            // uncontrolled
+
+        for (const role of dept.roles) {
+          if (role === 'public' || role === 'admin') continue;
+          if (!rbac.canAccessRoute(role, pattern)) {
+            offenders.push(`${slug}/${role} -> ${link}`);
+          }
+        }
+      }
+    }
+
+    // canUseTile filters these out at render time; this asserts we know about
+    // every one, so a new mismatch is a decision rather than a surprise.
+    assert.deepEqual(
+      offenders.sort(),
+      [
+        // A subcontractor's CIS department is wider than these two pages.
+        'construction-industry-scheme/accountant -> /subcontractor/assign',
+        'construction-industry-scheme/hmrc -> /subcontractor/assign',
+        'construction-industry-scheme/subcontractor -> /CIS/Dashboard/',
+        'construction-industry-scheme/subcontractor -> /subcontractor/assign',
+        // Payroll needs attendance, but /daily and /weekly do not admit
+        // accountants. A real gap, filtered out rather than papered over.
+        'payroll/accountant -> /daily',
+        'payroll/accountant -> /weekly',
+      ],
+      'a custom tile points somewhere its department cannot reach',
+    );
   });
 
   it('a role with no model grants can list nothing', () => {


### PR DESCRIPTION
Follows PR #73, which was merged as 6.22.0 while these four commits were still on its branch — they never made it into master. Rebased onto master and re-proposed here.

## Fixes

**`Gov-Client-Timezone` sent `UTC+697:00` to HMRC between 00:00 and 01:00 BST.** `_londonOffset()` formatted the time in London and UTC as `DD/MM/YYYY`, then fed both back to `new Date()`, which reads `MM/DD/YYYY`. Both sides misparsed identically most of the day, so the subtraction came out right and it stayed hidden. In the midnight hour the zones fall on different dates — 07/08 read as 8 July, 06/08 as 8 June, 30 days apart. Past the 12th it degrades to `UTCNaN:NaN` instead. Now uses `Intl` `longOffset`; verified across both DST transitions and the failing window.

**Dashboard tiles ignored role entirely.** `rbac.canAccess` returns `{allowed, ownOnly}`; the two filters in `indexController` used the bare return value, which is always truthy. Not a permission bypass — the routes carry their own guards — but every department showed its full tile list to anyone who could open it.

**Custom tiles now filter on the route they point at.** Two live 403-advertising tiles fixed: a subcontractor saw *CIS Dashboard* and *Edit CIS Details*; accountant and hmrc also saw *Edit CIS Details*, which is admin-only. Derived from `routeAccess` rather than a per-tile list so it cannot drift.

## Changed

`routeAccess` now covers the ten `/overview/*` pages, which were guarded only in `overviewRoutes.js` — each entry mirrors the existing guard, so nothing gains or loses access. Not a blanket `/overview`, because finance and payroll are wider than the rest.

IA re-filing: **Users moves from HR to Admin**; Attendances gains the Attendance department; the duplicate `AdminSettings` tile removed; Notification Settings under User only; Auditor tab added. Holiday tiles stay dual-homed in HR and Management on purpose — approving is a management job, administering is an HR job.

## Surfaced, not fixed

Both are the same pattern: permissions were dropped down route by route from an admin-only default, and the department gates never followed.

- Payroll is `admin, accountant` but `/daily` and `/weekly` admit only `admin, employee, subcontractor` — an accountant cannot open the attendance payroll needs.
- Five department gates are narrower than the routes inside them. `session` and `meta` are **not** among them — both are `deny`-blocked on purpose because they hold auth tokens, CSRF state and TOTP data.

## Verification
1098 tests, 1098 pass, exit 0.