### PR TITLE
feat: let accountants open attendance for payroll (6.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.24.0] - 2026-08-07
+
+### Added
+- **Accountants can open the daily and weekly attendance views.** Payroll is an `admin, accountant` department whose dashboard linked to `/daily` and `/weekly`, but those routes admitted only `admin, employee, subcontractor` — so an accountant could not open the attendance that running payroll depends on. 6.23.0 hid the broken tiles; this grants the access they were advertising.
+
+  Granted deliberately and unscoped (`attendance: 'r,l'`, not `:own`): a payroll run reads the whole period, not the accountant's own records. The weekly controller already treated `accountant` as payroll-privileged when deciding whether to strip pay figures — `!["admin", "accountant"].includes(role)` — so the intent was there all along and only the route guard had never caught up. Changed in all three places that have to agree: `roleModelAccess`, the two `ensureRoles` guards, and `routeAccess`.
+
+### Fixed
+- **The attendance controller treated "denied" and "unrestricted" as the same thing.** `scopeQuery` returns `null` when a role may not read a model at all and `{}` when it may read all of it — opposite outcomes. Both the daily filter (`if (!filter || Object.keys(filter).length === 0) return records`) and the weekly scoping block (`if (filter && Object.keys(filter).length > 0)`) fell through to *no filtering* on `null`, so a denial produced exactly the output of unrestricted access.
+
+  Latent rather than live: every role that could reach these routes already held an attendance grant, so the `null` branch was unreachable. That was a property of the route guard, not of the scoping — and this release widens that guard, which is precisely when it would have started returning every employee's attendance to a role the permission system had just refused. Fixed first, then the widening applied on top.
+
 ## [6.23.0] - 2026-08-07
 
 ### Fixed

--- a/mongoose/config/rolePermissionsConfig.js
+++ b/mongoose/config/rolePermissionsConfig.js
@@ -42,6 +42,11 @@ const roleModelAccess = {
   },
 
   accountant: {
+    // Unscoped, not ':own' — running payroll means reading everyone's
+    // attendance for the period. The weekly controller already treated
+    // accountant as payroll-privileged when deciding whether to strip pay
+    // figures; only the route guard had never been updated to let them in.
+    attendance:         'r,l',
     invoice:            'r,l',
     purchase:           'r,l',    // listed as "supplier" receipts in KashFlow
     supplier:           'r,l',
@@ -138,8 +143,11 @@ const ownershipFields = {
 // Maps route pattern → allowed roles.
 const routeAccess = {
   // Attendance views
-  '/daily':               ['admin', 'employee', 'subcontractor'],
-  '/weekly':              ['admin', 'employee', 'subcontractor'],
+  // 'accountant' reads these for payroll: Payroll is a periodic run, and the
+  // attendance for the period is its input. Everyone else here is scoped to
+  // their own records in the controller; the accountant is not, deliberately.
+  '/daily':               ['admin', 'accountant', 'employee', 'subcontractor'],
+  '/weekly':              ['admin', 'accountant', 'employee', 'subcontractor'],
   '/weekly-management':   ['admin'],
   '/attendance/submit':   ['employee', 'subcontractor'],
   '/attendance/approve':  ['admin'],

--- a/mongoose/controllers/attendanceController.js
+++ b/mongoose/controllers/attendanceController.js
@@ -29,7 +29,14 @@ import mongoose from 'mongoose';
 async function filterAttendanceForUser(req, records) {
   if (!req.user || req.user.role === "admin") return records;
   const filter = await scopeQuery(req, "attendance", "r");
-  if (!filter || Object.keys(filter).length === 0) return records;
+  // scopeQuery draws a distinction this used to collapse: `null` means the
+  // role may not read this model at all, `{}` means it may read all of it.
+  // Treating both as "return everything" made a denial indistinguishable from
+  // unrestricted access. Latent until now — every role that could reach this
+  // route already held an attendance grant — but it would have become live
+  // the moment one that did not was let in.
+  if (filter === null) return [];
+  if (Object.keys(filter).length === 0) return records;
   return records.filter((rec) => {
     return Object.entries(filter).every(([k, v]) => {
       const val = rec[k]?._id || rec[k]; // handle populated refs
@@ -97,7 +104,10 @@ export const getWeeklyAttendance = async (req, res, next) => {
     let scopedGrouped = groupedAttendance;
     if (req.user && req.user.role !== "admin") {
       const filter = await scopeQuery(req, "attendance", "r");
-      if (filter && Object.keys(filter).length > 0) {
+      // Same null-means-denied distinction as filterAttendanceForUser above.
+      if (filter === null) {
+        scopedGrouped = {};
+      } else if (Object.keys(filter).length > 0) {
         // groupedAttendance is keyed by person uuid; each value has entityId (the ObjectId)
         const filterField = Object.keys(filter)[0]; // e.g. 'employeeId' or 'subcontractorId'
         const filterValue = String(filter[filterField]);

--- a/mongoose/routes/attendanceRoutes.js
+++ b/mongoose/routes/attendanceRoutes.js
@@ -3,15 +3,19 @@ const router = express.Router();
 import authService from '../../services/authService.js';
 import ctrl from '../controllers/attendanceController.js';
 
-// Daily / weekly views — admin sees all; employee/subcontractor sees own (scoped in controller)
+// Daily / weekly views — admin and accountant see all; employee/subcontractor
+// see their own (scoped in controller). The accountant is here because payroll
+// is a periodic run over the period's attendance, and Payroll is an
+// admin+accountant department that previously linked to a page its own users
+// could not open.
 router.get(
   "/daily/:date?",
-  authService.ensureRoles("admin", "employee", "subcontractor"),
+  authService.ensureRoles("admin", "accountant", "employee", "subcontractor"),
   ctrl.getDailyAttendance,
 );
 router.get(
   "/weekly/:year?/:week?",
-  authService.ensureRoles("admin", "employee", "subcontractor"),
+  authService.ensureRoles("admin", "accountant", "employee", "subcontractor"),
   ctrl.getWeeklyAttendance,
 );
 router.get(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.23.0",
+  "version": "6.24.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/tests/attendanceScoping.test.js
+++ b/tests/attendanceScoping.test.js
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import rbac from '../mongoose/config/rolePermissionsConfig.js';
+
+/**
+ * scopeQuery returns three different things, and two of them look alike:
+ *
+ *   null  – this role may not read this model at all  (caller should refuse)
+ *   {}    – this role may read all of it              (caller should not filter)
+ *   {...} – this role may read its own records only
+ *
+ * The attendance controller collapsed `null` and `{}` into "return
+ * everything", so a denial produced the same output as unrestricted access.
+ * Nothing exploited it, because every role that could reach /daily already
+ * held an attendance grant — but that was a property of the route guard, not
+ * of the scoping, and the guard has now been widened.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const controllerSrc = fs.readFileSync(
+  path.join(ROOT, 'mongoose/controllers/attendanceController.js'), 'utf8',
+);
+const routesSrc = fs.readFileSync(
+  path.join(ROOT, 'mongoose/routes/attendanceRoutes.js'), 'utf8',
+);
+
+describe('attendance scoping', () => {
+  it('never treats a null (denied) scope as unrestricted', () => {
+    // The exact shape that conflated them. `!filter` is true for null AND for
+    // any empty-ish value, which is what made the denial invisible.
+    assert.equal(
+      /if\s*\(\s*!filter\s*\|\|\s*Object\.keys\(filter\)\.length === 0\s*\)\s*return records/.test(controllerSrc),
+      false,
+      'filterAttendanceForUser is treating a denied scope as unrestricted again',
+    );
+    assert.ok(
+      controllerSrc.includes('if (filter === null) return [];'),
+      'filterAttendanceForUser should return nothing when the scope is a denial',
+    );
+  });
+
+  it('the weekly view distinguishes denial from unrestricted too', () => {
+    assert.equal(
+      /if\s*\(\s*filter\s*&&\s*Object\.keys\(filter\)\.length > 0\s*\)/.test(controllerSrc),
+      false,
+      'the weekly scoping block silently skips filtering on a denied scope',
+    );
+  });
+});
+
+describe('accountant attendance access', () => {
+  it('is granted unscoped read, matching what payroll needs', () => {
+    const { allowed, ownOnly } = rbac.canAccess('accountant', 'attendance', 'r');
+    assert.equal(allowed, true, 'accountant should be able to read attendance');
+    assert.equal(ownOnly, false, 'payroll needs everyone, not the accountant\'s own records');
+  });
+
+  it('is admitted by both the route guard and routeAccess', () => {
+    // Two independent layers; a role in one and not the other either 403s at
+    // the guard or is refused by ensureRouteAccess before reaching it.
+    for (const p of ['/daily', '/weekly']) {
+      assert.equal(rbac.canAccessRoute('accountant', p), true, `routeAccess omits accountant for ${p}`);
+    }
+    const guards = routesSrc.match(/ensureRoles\([^)]*\)/g) || [];
+    const attendanceViews = guards.filter(g => g.includes('employee') && g.includes('subcontractor'));
+    assert.ok(attendanceViews.length >= 2, 'expected the daily and weekly guards');
+    for (const g of attendanceViews.slice(0, 2)) {
+      assert.ok(g.includes('accountant'), `route guard omits accountant: ${g}`);
+    }
+  });
+
+  it('does not accidentally widen anyone else', () => {
+    // client, hmrc and auditor have no business in attendance.
+    for (const role of ['client', 'hmrc', 'auditor']) {
+      assert.equal(
+        rbac.canAccess(role, 'attendance', 'r').allowed, false,
+        `${role} should not be able to read attendance`,
+      );
+      assert.equal(rbac.canAccessRoute(role, '/daily'), false, `${role} should not reach /daily`);
+    }
+    // employee and subcontractor keep their own-records-only scoping.
+    for (const role of ['employee', 'subcontractor']) {
+      const { allowed, ownOnly } = rbac.canAccess(role, 'attendance', 'r');
+      assert.equal(allowed, true);
+      assert.equal(ownOnly, true, `${role} must stay scoped to their own records`);
+    }
+  });
+});

--- a/tests/dashboardRoleFilter.test.js
+++ b/tests/dashboardRoleFilter.test.js
@@ -81,10 +81,9 @@ describe('dashboard tile role filtering', () => {
         'construction-industry-scheme/hmrc -> /subcontractor/assign',
         'construction-industry-scheme/subcontractor -> /CIS/Dashboard/',
         'construction-industry-scheme/subcontractor -> /subcontractor/assign',
-        // Payroll needs attendance, but /daily and /weekly do not admit
-        // accountants. A real gap, filtered out rather than papered over.
-        'payroll/accountant -> /daily',
-        'payroll/accountant -> /weekly',
+        // The two payroll/accountant entries that used to be here are gone:
+        // /daily and /weekly now admit accountants, because running payroll
+        // means reading the period's attendance.
       ],
       'a custom tile points somewhere its department cannot reach',
     );


### PR DESCRIPTION
Closes the gap 6.23.0 surfaced.

## The gap
Payroll is an `admin, accountant` department whose dashboard linked to `/daily` and `/weekly`, but those routes admitted only `admin, employee, subcontractor`. An accountant could not open the attendance that running payroll depends on. 6.23.0 hid the broken tiles; this grants the access they were advertising.

Granted **unscoped** (`attendance: 'r,l'`, not `:own`) — a payroll run reads the whole period. Changed in all three layers that must agree: `roleModelAccess`, the two `ensureRoles` guards, and `routeAccess`.

The intent predates this change: the weekly controller already treated accountant as payroll-privileged when deciding whether to strip pay figures (`!['admin','accountant'].includes(role)`). Only the route guard never caught up.

## The bug that had to be fixed first
`scopeQuery` returns `null` for "may not read this model at all" and `{}` for "may read all of it" — opposite outcomes. Both attendance call sites fell through to **no filtering** on `null`:

```js
if (!filter || Object.keys(filter).length === 0) return records;   // daily
if (filter && Object.keys(filter).length > 0) { ...scope... }      // weekly
```

So a denial produced exactly the output of unrestricted access. Latent, because every role that could reach these routes already held an attendance grant — but that was a property of the route guard, and this PR widens that guard. Adding accountant on top of the old code would have handed them every employee's attendance *through the branch meant to refuse them*.

Fixed first, widening applied on top.

## Tests
`tests/attendanceScoping.test.js` pins the null-vs-`{}` distinction at both call sites and the three-layer grant, and asserts client/hmrc/auditor stay out while employee/subcontractor stay scoped to their own records. The offender list in `dashboardRoleFilter.test.js` loses its two payroll/accountant entries.

**1103 tests, 1103 pass, exit 0.**