### PR TITLE
Surface the synced KashFlow reference collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.26.0] - 2026-08-18
+
+### Added
+- **Seven KashFlow collections that hcs-sync has been mirroring hourly are now readable.** `journals`, `vatreturns`, `accountingperiods`, `countries`, `currencies`, `quotecategories` and `purchaseordercategories` were synced on every run and read by nothing. They were never *unreachable* — the generic list route is registered for every model in the namespace whether or not it has a config — but with no `listControllerConfig` entry they had no title, no field order, no hidden sync metadata, and above all **no `department`**, which is what puts a tile on a dashboard. So they existed for admins only, rendered raw, at URLs nothing linked to.
+
+  Each is read-only (`deny: ['c','u','d']`) and on the finance dashboard, with the accountant granted `r,l`. KashFlow remains the system of record.
+
+  **Surfacing one of these takes four declarations that do not share a key**, and the two path keys are the trap: `listRoutes.js` reads `pathOverride` for the route, `indexController.js` reads `listPath` for the tile link, neither falls back to the other, and both default to a naive `model + 's'`. An irregular plural therefore yields a tile pointing at `/countrys` while the route is `/countries`. `tests/listConfigPaths.test.js` pins route-equals-tile for **every** entry that earns a tile, not just the new ones.
+
+- **`product` and `purchaseOrder` are deliberately left unconfigured**, and a test asserts it. Both return 0 rows from KashFlow on every run — this business uses neither the product catalogue nor purchase orders — so a tile would advertise a permanently empty page. The models and routes already exist if that changes.
+
+### Fixed
+- **The "OCR Documents" dashboard tile linked to a page that does not exist.** `OcrDocument` sets `pathOverride: '/paperless'`, which moves the route; the tile link comes from `listPath`, which was unset, so it fell back to `/OcrDocuments` — a path no router registers. The documents dashboard has been advertising a 404. This is the same shape as the 6.23.0 tile bug (dashboards advertising links that answer 403) and was missed for the same reason: the two halves are declared in different files under different names.
+
+  Eight further entries (`employeeHoliday`, `holidayRequest`, `holidayDismissal`, `holidayCustom`, `OcrDocumentIngest`, `vehicleFuelLog`, `vehicleMileageLog`, `vehicleService`) had camelCase tile links against lowercased routes. Those worked, but only because Express routing is case-insensitive by default — a framework default nobody set on purpose. All now state the path explicitly.
+
+- **`fieldOrder` orders columns but does not restrict them**, so every field not in `hideFields` was appended after it — the VAT returns table came out 22 columns wide, nine of them VAT boxes, and `countries` grew a stray KashFlow `Id`. All seven now set `strictOrder`, which makes `fieldOrder` definitive and stops a field KashFlow starts returning from arriving as an unannounced column (`PVABoxTextChangeFrom` did exactly that). The VAT return list is eight columns — Box 5, the net payable, being the one box worth a column — while the detail page still shows all 21 fields, via a `fieldOrder` in `CRUDControllerConfig`, which wins in `getMergedConfig`.
+
+- **A filter type that silently filtered nothing.** `applyFilterParams` implements `boolean`, `select`, `daterange` and `numberrange`; anything else renders a control that never applies. The VAT return payment filter is a `select` over KashFlow's real values (`Paid`, `Unpaid`, `-`).
+
+### Notes
+Two things found while reading the synced data that are **not** fixed here, because both belong upstream in `@cappytech/hcs-schemas`:
+
+- **The `journal` entity does not describe the payload KashFlow actually returns.** It declares `Id`, `Date`, `Description` and `Lines`; the list endpoint returns none of them (0 of 400 rows have `Id` or `Date`). The real fields are `Number`, `JournalName`, `JournalDate`, `Comment`, `TotalAmount` and friends, which survive only because the model is `strict: false`. **`Lines` — the nominal debit/credit pairs — is not synced at all**, existing only on the per-journal detail endpoint that hcs-sync never calls. Anything intending to reconcile a bank line against a journal needs that fetch added to hcs-sync first; note also that `LockedBankLines` is 0 on all 400 rows, so no journal in this ledger currently touches a bank line.
+- **`accountingPeriod.IsLocked` does not exist.** 0 of 8 rows carry it. `IsCurrentPeriod` is the field that distinguishes the open period. A period-close check must derive "closed" from the dates and `IsCurrentPeriod`, not from `IsLocked`.
+
+Dates in all three of these collections are stored as `"YYYY-MM-DDTHH:mm:ss"` **strings**, not `Date`s — the same cause as the `banktransactions.Date` migration (hcs-sync upserts through the native driver with `$literal` and never hits Mongoose casting). Sorting works, since that format is lexicographically chronological; date-range filters would not, so none are configured. `vatreturns.FileDate` carries the .NET sentinel `0001-01-01T00:00:00` for "never filed".
+
 ## [6.25.0] - 2026-08-18
 
 ### Added

--- a/mongoose/config/CRUDControllerConfig.js
+++ b/mongoose/config/CRUDControllerConfig.js
@@ -581,6 +581,60 @@ export default {
       read: ['ensureRoles:admin,accountant'],
     }
   },
+  // KashFlow reference collections mirrored by hcs-sync. Read-only for the
+  // same reason as `nominal` above: KashFlow owns them, the generic write
+  // routes are denied in listControllerConfig, and only the read middleware
+  // is widened. Without an entry here the list route defaults to
+  // `ensureRole:admin` and an accountant gets a 403 on a tile they can see.
+  journal: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  vatReturn: {
+    readOnly: ['uuid', 'createdAt'],
+    // The detail page shows the whole return; the list shows eight columns.
+    // getMergedConfig spreads CRUDControllerConfig over listControllerConfig,
+    // so this fieldOrder overrides the narrow one there rather than merging.
+    fieldOrder: ['PeriodId', 'StartDate', 'EndDate', 'DueDate', 'Status', 'PaidStatus',
+      'Box1', 'Box2', 'Box3', 'Box4', 'Box5', 'Box6', 'Box7', 'Box8', 'Box9',
+      'TransactionsCount', 'FileDate', 'SubmissionErrorMessage',
+      'IsSourceMTD', 'IsCashAccounting', 'AreVatNumbersValid'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  accountingPeriod: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  country: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  currency: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  quoteCategory: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
+  purchaseOrderCategory: {
+    readOnly: ['uuid', 'createdAt'],
+    middleware: {
+      read: ['ensureRoles:admin,accountant'],
+    }
+  },
   note: { 
     readOnly: ['uuid', 'createdAt'],
     middleware: {

--- a/mongoose/config/listControllerConfig.js
+++ b/mongoose/config/listControllerConfig.js
@@ -1010,6 +1010,10 @@ export default {
   },
   employeeHoliday: {
     title: 'Employee Holiday',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/employeeholidays',
     // Show periodStart as the clickable link into the record
     linkField: 'periodStart',
     hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid'],
@@ -1056,6 +1060,10 @@ export default {
   },
   holidayRequest: {
     title: 'Holiday Requests',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/holidayrequests',
     linkField: 'startDate',
     hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid'],
     fieldOrder: [
@@ -1207,6 +1215,10 @@ export default {
   },
   holidayDismissal: {
     title: 'Dismissed Holidays',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/holidaydismissals',
     description: {
       manage: 'Manage company holidays'
     },
@@ -1239,6 +1251,10 @@ export default {
   },
   holidayCustom: {
     title: 'Company Holidays',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/holidaycustoms',
     description: {
       create: 'Create a company holiday',
       manage: 'Manage company holidays'
@@ -1251,6 +1267,10 @@ export default {
   },
   OcrDocument: {
     title: 'OCR Documents',
+    // The route is `/paperless` (pathOverride above), so the tile must say so
+    // too. `listPath` defaults to `/OcrDocuments`, which is not a route on
+    // this app at all — the documents dashboard tile linked to a 404.
+    listPath: '/paperless',
     description: {
       manage: 'Manage OCR documents imported from Paperless-ngx.'
     },
@@ -1265,6 +1285,10 @@ export default {
   },
   OcrDocumentIngest: {
     title: 'OCR Ingest Log',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/ocrdocumentingests',
     description: {
       manage: 'Paperless-ngx document ingest status and sync tracking.'
     },
@@ -1363,8 +1387,270 @@ export default {
     department: ['finance'],
     deny: ['c', 'u', 'd'],
   },
+
+  // ── KashFlow reference collections synced by hcs-sync ─────────────────
+  //
+  // These are mirrored on every hourly run and, until now, read by nothing:
+  // no config meant no title, no field order, no department — so no dashboard
+  // tile, and the generic list route rendered every raw sync field to admins
+  // at an URL nothing linked to. All are read-only here; KashFlow owns them.
+  //
+  // Three files have to agree to surface one of these, and they use different
+  // keys for the same idea:
+  //   1. here          — `pathOverride` sets the ROUTE (listRoutes.js)
+  //   2. here          — `listPath` sets the TILE LINK (indexController.js)
+  //   3. CRUDControllerConfig — middleware.read, or the route stays admin-only
+  //   4. rolePermissionsConfig — roleModelAccess, or the tile is filtered out
+  // `pathOverride` and `listPath` are read by different modules and neither
+  // falls back to the other, so an irregular plural needs BOTH or the tile
+  // links to a 404 (`/countrys`). Keys must be the exact camelCase modelName:
+  // listRoutes looks up `__listControllerConfig[originalModel]` and a
+  // lowercased key silently misses (see `vatrate`, which only works because
+  // its default plural happens to be correct).
+  //
+  // `product` and `purchaseOrder` are deliberately NOT configured: both return
+  // 0 rows from KashFlow on every run (checked across 12 consecutive runs —
+  // this business uses neither the product catalogue nor purchase orders), so
+  // a tile would advertise a permanently empty page. Add config here if that
+  // ever changes; the models and routes already exist.
+  journal: {
+    title: 'Journals',
+    description: {
+      manage: 'KashFlow journal entries — manual double-entry adjustments.'
+    },
+    linkField: 'JournalName',
+    // NOTE: the hcs-schemas `journal` entity does not describe this payload.
+    // It declares Id / Date / Description / Lines; KashFlow's list endpoint
+    // returns none of those. The real fields are below. The model is
+    // `strict: false`, which is the only reason the data survived at all.
+    // `Lines` (the nominal debit/credit pairs) is NOT synced — it exists only
+    // on the per-journal detail endpoint, which hcs-sync never calls.
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      // hcs-sync bookkeeping, meaningless to a reader
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt',
+      // Category is KashFlow's integer enum; CategoryDescription is the label
+      'Category',
+      // Journal templates are not used here — both fields are empty on all rows
+      'IsTemplate', 'TemplateName'],
+    fieldOrder: ['Number', 'JournalName', 'JournalDate', 'Comment', 'TotalAmount',
+      'CategoryDescription', 'TradeBorderType', 'ExcludedFromProfitAndLoss',
+      'VATReturnId', 'LockedBankLines'],
+    strictOrder: true,
+    labelOverrides: {
+      JournalName: 'Reference',
+      JournalDate: 'Date',
+      Comment: 'Description',
+      TotalAmount: 'Total',
+      CategoryDescription: 'Category',
+      ExcludedFromProfitAndLoss: 'Excluded from P&L',
+      VATReturnId: 'VAT Return',
+      LockedBankLines: 'Locked Bank Lines',
+    },
+    // JournalDate is stored as a "YYYY-MM-DDTHH:mm:ss" STRING, not a Date —
+    // hcs-sync upserts through the native driver with $literal and never hits
+    // Mongoose casting (the same fault as banktransactions.Date before its
+    // migration). Sorting still works because that format is lexicographically
+    // chronological. A date-RANGE filter would not, which is why there is none.
+    sortField: 'JournalDate',
+    sortOrder: -1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+    tabsby: 'CategoryDescription',
+    tabsDynamic: true,
+  },
+  vatReturn: {
+    title: 'VAT Returns',
+    description: {
+      manage: 'VAT returns as filed in KashFlow, with box figures and payment status.'
+    },
+    linkField: 'PeriodId',
+    // Stated explicitly rather than relying on the default plural: the tile
+    // link would otherwise be camelCase (`/vatReturns`) and the route lowercase,
+    // matching only because Express routing is case-insensitive by default.
+    pathOverride: '/vatreturns',
+    listPath: '/vatreturns',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt',
+      // EC Sales List — not applicable to a domestic construction business
+      'ECSLStatus', 'ECSLSubmissionErrorMessage', 'ECSLSubmissionResponseTimeStamp',
+      // KashFlow internals with no meaning outside it
+      'SubmittedBy', 'VatReturnBatchItemId', 'RegisteredIn', 'HasCSV',
+      'SubmissionResponseTimeStamp', 'PVABoxTextChangeFrom',
+      // Flat-rate scheme is not in use; both are null on every row
+      'IsFRS', 'FRSRate'],
+    // LIST columns only. fieldOrder does not restrict columns by itself —
+    // anything not hidden is appended after it — so `strictOrder` below makes
+    // this the definitive set. All 21 fields, including the other eight boxes,
+    // are on the detail page: CRUDControllerConfig wins in getMergedConfig.
+    // Box 5 is the headline figure (net VAT payable), so it is the one box
+    // worth a column; nine box columns make the table unreadable.
+    fieldOrder: ['PeriodId', 'StartDate', 'EndDate', 'DueDate', 'Status', 'PaidStatus',
+      'Box5', 'TransactionsCount'],
+    strictOrder: true,
+    labelOverrides: {
+      PeriodId: 'Period',
+      DueDate: 'Due',
+      PaidStatus: 'Payment',
+      Box1: 'Box 1 — VAT due on sales',
+      Box2: 'Box 2 — VAT due on EC acquisitions',
+      Box3: 'Box 3 — Total VAT due',
+      Box4: 'Box 4 — VAT reclaimed',
+      Box5: 'Box 5 — Net VAT to pay',
+      Box6: 'Box 6 — Total sales ex VAT',
+      Box7: 'Box 7 — Total purchases ex VAT',
+      Box8: 'Box 8 — EC supplies',
+      Box9: 'Box 9 — EC acquisitions',
+      TransactionsCount: 'Transactions',
+      FileDate: 'Filed',
+      IsSourceMTD: 'MTD',
+      IsCashAccounting: 'Cash Accounting',
+      AreVatNumbersValid: 'VAT Numbers Valid',
+      SubmissionErrorMessage: 'Submission Error',
+    },
+    // Same string-date caveat as `journal` above; ISO strings sort correctly.
+    // FileDate carries the .NET "never" sentinel 0001-01-01T00:00:00 on
+    // returns that were never filed — it is not a real date, do not parse it
+    // into a "filed 2000 years ago" figure.
+    sortField: 'EndDate',
+    sortOrder: -1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+    tabsby: 'Status',
+    tabsDynamic: true,
+    filters: [
+      // Only 'boolean', 'select', 'daterange' and 'numberrange' are implemented
+      // in applyFilterParams — an unrecognised type renders a control that
+      // silently filters nothing. '-' is KashFlow's own value for a return
+      // with no payment status, not a placeholder for missing data.
+      { field: 'PaidStatus', label: 'Payment', type: 'select', options: [
+        { value: 'Paid', label: 'Paid' },
+        { value: 'Unpaid', label: 'Unpaid' },
+        { value: '-', label: 'Not applicable' },
+      ] },
+    ],
+    // Deliberately no 'daterange' filter on StartDate/EndDate/DueDate: those
+    // are stored as strings, and the daterange branch builds `new Date(...)`
+    // bounds, which match no string value at all — a filter that quietly
+    // returns nothing is worse than no filter.
+  },
+  accountingPeriod: {
+    title: 'Accounting Periods',
+    description: {
+      manage: 'KashFlow accounting periods and which one is currently open.'
+    },
+    linkField: 'StartDate',
+    // Stated explicitly rather than relying on the default plural: the tile
+    // link would otherwise be camelCase (`/accountingPeriods`) and the route lowercase,
+    // matching only because Express routing is case-insensitive by default.
+    pathOverride: '/accountingperiods',
+    listPath: '/accountingperiods',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt'],
+    // NOTE: hcs-schemas declares `IsLocked` on this entity. KashFlow does not
+    // return it — 0 of 8 rows have the field. `IsCurrentPeriod` is what
+    // actually distinguishes the open period, and it is the only boolean here.
+    // Anything asking "is this period closed?" must derive it from the dates
+    // and IsCurrentPeriod, not from IsLocked.
+    fieldOrder: ['Id', 'StartDate', 'EndDate', 'IsCurrentPeriod', 'JournalRef', 'YearEndJournalId'],
+    strictOrder: true,
+    labelOverrides: {
+      IsCurrentPeriod: 'Current',
+      JournalRef: 'Journal Ref',
+      YearEndJournalId: 'Year-End Journal',
+    },
+    sortField: 'StartDate',
+    sortOrder: -1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+  },
+  country: {
+    title: 'Countries',
+    description: {
+      manage: 'KashFlow country list used for supplier and customer addresses.'
+    },
+    linkField: 'Name',
+    // Irregular plural: both keys required, and they must match. See the
+    // block comment at the head of this group.
+    pathOverride: '/countries',
+    listPath: '/countries',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt'],
+    fieldOrder: ['Code', 'Name', 'IsEU'],
+    strictOrder: true,
+    labelOverrides: { IsEU: 'EU' },
+    sortField: 'Name',
+    sortOrder: 1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+    filters: [
+      { field: 'IsEU', label: 'EU', type: 'boolean', falseLabel: 'Non-EU', trueLabel: 'EU' },
+    ],
+  },
+  currency: {
+    title: 'Currencies',
+    description: {
+      manage: 'KashFlow currencies and exchange rates.'
+    },
+    linkField: 'Code',
+    pathOverride: '/currencies',
+    listPath: '/currencies',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt'],
+    fieldOrder: ['Code', 'Name', 'Symbol', 'ExchangeRate', 'AutoUpdate', 'DisplaySymbolOnRight'],
+    strictOrder: true,
+    labelOverrides: {
+      ExchangeRate: 'Exchange Rate',
+      AutoUpdate: 'Auto Update',
+      DisplaySymbolOnRight: 'Symbol on Right',
+    },
+    sortField: 'Code',
+    sortOrder: 1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+  },
+  quoteCategory: {
+    title: 'Quote Categories',
+    description: {
+      manage: 'Categories used to group KashFlow quotes.'
+    },
+    linkField: 'Name',
+    pathOverride: '/quotecategories',
+    listPath: '/quotecategories',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt',
+      // KashFlow UI icon styling — no meaning in this app
+      'IconColor', 'IconId', 'IconType'],
+    fieldOrder: ['Number', 'Name'],
+    strictOrder: true,
+    sortField: 'Number',
+    sortOrder: 1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+  },
+  purchaseOrderCategory: {
+    title: 'Purchase Order Categories',
+    description: {
+      manage: 'Categories used to group KashFlow purchase orders.'
+    },
+    linkField: 'Name',
+    pathOverride: '/purchaseordercategories',
+    listPath: '/purchaseordercategories',
+    hideFields: ['_id', 'createdAt', 'updatedAt', 'uuid',
+      '_kfHash', 'syncedAt', 'createdByRunId', 'deletedAt', 'DeletedAt',
+      'IconColor', 'IconId', 'IconType'],
+    fieldOrder: ['Number', 'Name'],
+    strictOrder: true,
+    sortField: 'Number',
+    sortOrder: 1,
+    department: ['finance'],
+    deny: ['c', 'u', 'd'],
+  },
   vehicleFuelLog: {
     title: 'Fuel Logs',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/vehiclefuellogs',
     description: {
       create: 'Record a fuel fill-up for a vehicle.',
       manage: 'Track fuel receipts, costs and consumption across the fleet.',
@@ -1422,6 +1708,10 @@ export default {
   },
   vehicleMileageLog: {
     title: 'Mileage Logs',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/vehiclemileagelogs',
     description: {
       create: 'Record a trip / odometer reading for a vehicle.',
       manage: 'Track mileage, trips and HMRC mileage claims.',
@@ -1488,6 +1778,10 @@ export default {
   },
   vehicleService: {
     title: 'Service History',
+    // Stated explicitly: `listPath` (tile) defaults to camelCase while the
+    // route is lowercased, so these matched only because Express routing is
+    // case-insensitive by default.
+    listPath: '/vehicleservices',
     description: {
       create: 'Record a service, MOT or repair for a vehicle.',
       manage: 'View and manage vehicle service history and costs.',

--- a/mongoose/config/rolePermissionsConfig.js
+++ b/mongoose/config/rolePermissionsConfig.js
@@ -55,6 +55,18 @@ const roleModelAccess = {
     quote:              'r,l',
     nominal:            'r,l',
     note:               'r,l',
+    // KashFlow reference collections mirrored by hcs-sync. Read-only
+    // everywhere — the write ops are denied in listControllerConfig, so 'r,l'
+    // is the whole grant. Without these the finance dashboard filters the
+    // tiles out for accountants (getDashboardModels checks canAccess) and the
+    // pages exist for admins only.
+    journal:               'r,l',
+    vatReturn:             'r,l',
+    accountingPeriod:      'r,l',
+    country:               'r,l',
+    currency:              'r,l',
+    quoteCategory:         'r,l',
+    purchaseOrderCategory: 'r,l',
     vehicleDeployment:  'c,r,u,l',
     assignment:         'c,r,u,l',
     // Bank reconciliation. The KashFlow-synced collections are read-only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.21.2",
+  "version": "6.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.21.2",
+      "version": "6.26.0",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.25.0",
+  "version": "6.26.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/tests/listConfigPaths.test.js
+++ b/tests/listConfigPaths.test.js
@@ -1,0 +1,140 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import listConfig from '../mongoose/config/listControllerConfig.js';
+import crudConfig from '../mongoose/config/CRUDControllerConfig.js';
+import rbac from '../mongoose/config/rolePermissionsConfig.js';
+
+/**
+ * Surfacing one synced collection means four separate declarations agreeing,
+ * and they do not share a key:
+ *
+ *   listRoutes.js      reads `pathOverride`  -> the ROUTE
+ *   indexController.js reads `listPath`      -> the TILE LINK
+ *   CRUDControllerConfig  middleware.read    -> who may open the route
+ *   rolePermissionsConfig roleModelAccess    -> who is shown the tile
+ *
+ * Neither path key falls back to the other, and both default to a naive
+ * `model + 's'`. So an irregular plural gives a tile pointing at `/countrys`
+ * while the route is `/countries` — a dashboard link that 404s, with nothing
+ * logged and no error anywhere. That is the class of fault these tests pin.
+ */
+
+const denied = (config, op) => Array.isArray(config.deny) && config.deny.includes(op);
+
+// Mirrors the path computation in mongoose/routes/listRoutes.js.
+const routePathFor = (model, config) => {
+  if (config.pathOverride) {
+    return config.pathOverride.startsWith('/') ? config.pathOverride : `/${config.pathOverride}`;
+  }
+  const routeModel = (config.modelRename || model).toLowerCase();
+  const parts = routeModel.split('/').filter(Boolean);
+  const last = parts.pop();
+  return `/${[...parts, `${last}s`].join('/')}`;
+};
+
+// Mirrors the tile link computation in mongoose/controllers/indexController.js.
+const tilePathFor = (model, config) => config.listPath || `/${model}s`;
+
+// Every entry that earns a dashboard tile: it names a department and is listable.
+const tiledEntries = Object.entries(listConfig)
+  .filter(([, config]) => Array.isArray(config?.department) && config.department.length > 0)
+  .filter(([, config]) => !denied(config, 'l'));
+
+describe('list config route/tile agreement', () => {
+  it('has tiled entries to check', () => {
+    assert.ok(tiledEntries.length > 5, `expected several tiled entries, found ${tiledEntries.length}`);
+  });
+
+  for (const [model, config] of tiledEntries) {
+    it(`${model}: the tile link and the route are the same path`, () => {
+      const route = routePathFor(model, config);
+      const tile = tilePathFor(model, config);
+      assert.equal(
+        tile, route,
+        `tile links to ${tile} but the route is ${route} — set both listPath and pathOverride`,
+      );
+    });
+
+    it(`${model}: the path is spelled identically, not just case-insensitively`, () => {
+      // Express routing is case-insensitive by default, so a camelCase tile
+      // against a lowercased route happens to work. Relying on a framework
+      // default nobody set on purpose is how it stops working.
+      const route = routePathFor(model, config);
+      assert.equal(route, route.toLowerCase(), `${model} route ${route} is not lowercase`);
+    });
+  }
+});
+
+describe('KashFlow reference collections are readable by finance', () => {
+  // These are mirrored hourly by hcs-sync and were read by nothing until they
+  // were configured: no config meant no title, no department, and therefore no
+  // tile — the pages existed for admins at URLs nothing linked to.
+  const referenceModels = [
+    'journal', 'vatReturn', 'accountingPeriod',
+    'country', 'currency', 'quoteCategory', 'purchaseOrderCategory',
+  ];
+
+  for (const model of referenceModels) {
+    it(`${model} is configured, read-only, and on the finance dashboard`, () => {
+      const config = listConfig[model];
+      assert.ok(config, `${model} has no listControllerConfig entry`);
+      assert.ok(config.department?.includes('finance'), `${model} is not on the finance dashboard`);
+      // KashFlow owns these. The write ops must stay denied, which is what
+      // makes a plain 'r,l' grant the whole story.
+      for (const op of ['c', 'u', 'd']) {
+        assert.ok(denied(config, op), `${model} must deny '${op}' — KashFlow is the system of record`);
+      }
+    });
+
+    it(`${model}: an accountant may list it and may not write it`, () => {
+      assert.equal(rbac.canAccess('accountant', model, 'l').allowed, true, `${model} not listable by accountant`);
+      assert.equal(rbac.canAccess('accountant', model, 'u').allowed, false, `${model} is writable by accountant`);
+    });
+
+    it(`${model}: the read middleware admits the accountant the tile is shown to`, () => {
+      // Without an entry here the route falls back to the config default,
+      // `ensureRole:admin` — so the accountant sees a tile and gets a 403.
+      const read = crudConfig[model]?.middleware?.read;
+      assert.ok(read, `${model} has no CRUDControllerConfig middleware.read`);
+      assert.ok(
+        read.some((m) => m.startsWith('ensureRoles:') && m.includes('accountant')),
+        `${model} read middleware ${JSON.stringify(read)} excludes accountant`,
+      );
+    });
+  }
+
+  it('pins the column set, so a new KashFlow field cannot appear as a column', () => {
+    // fieldOrder ORDERS columns; it does not restrict them. Anything not in
+    // hideFields is appended after it, so a field KashFlow starts returning
+    // (PVABoxTextChangeFrom did exactly this) arrives as an unannounced
+    // column. strictOrder makes fieldOrder the definitive list.
+    for (const model of referenceModels) {
+      assert.equal(listConfig[model].strictOrder, true, `${model} does not set strictOrder`);
+    }
+  });
+
+  it('vatReturn lists eight columns but shows the whole return on the detail page', () => {
+    // Nine VAT box columns make the list unreadable, and Box 5 is the headline
+    // figure. The full set lives in CRUDControllerConfig, which wins in
+    // getMergedConfig — so narrowing the list must not narrow the detail page.
+    const listOrder = listConfig.vatReturn.fieldOrder;
+    const detailOrder = crudConfig.vatReturn.fieldOrder;
+    assert.ok(detailOrder, 'vatReturn has no detail fieldOrder');
+    assert.ok(listOrder.length < detailOrder.length, 'the list is not narrower than the detail page');
+    assert.ok(listOrder.includes('Box5'), 'Box 5 is the net VAT payable and belongs in the list');
+    for (const box of ['Box1', 'Box2', 'Box3', 'Box4', 'Box6', 'Box7', 'Box8', 'Box9']) {
+      assert.ok(!listOrder.includes(box), `${box} should not be a list column`);
+      assert.ok(detailOrder.includes(box), `${box} is missing from the detail page`);
+    }
+  });
+
+  it('does not configure the two collections KashFlow returns empty', () => {
+    // product and purchaseOrder sync 0 rows on every run; a tile would
+    // advertise a permanently empty page. If KashFlow starts returning them,
+    // configure them and delete this assertion — do not weaken it in place.
+    for (const model of ['product', 'purchaseOrder']) {
+      assert.equal(listConfig[model], undefined, `${model} is configured but syncs 0 rows`);
+    }
+  });
+});


### PR DESCRIPTION
hcs-sync mirrors 21 KashFlow entities every hour. Seven of them were read by nothing.

They were never *unreachable* — `listController` registers a route for every model in the namespace whether or not it has a config — but with no `listControllerConfig` entry they had no title, no field order, no hidden sync metadata, and above all **no `department`**, which is what puts a tile on a dashboard. So they existed for admins only, rendered raw, at URLs nothing linked to.

`journals`, `vatreturns`, `accountingperiods`, `countries`, `currencies`, `quotecategories` and `purchaseordercategories` are now configured, read-only (`deny: ['c','u','d']`), on the finance dashboard, with the accountant granted `r,l`. KashFlow remains the system of record.

## The trap this exposed

Surfacing one of these takes **four declarations that do not share a key**:

| what | where | key |
| --- | --- | --- |
| the route | `listRoutes.js` | `pathOverride` |
| the tile link | `indexController.js` | `listPath` |
| who may open the route | `CRUDControllerConfig` | `middleware.read` |
| who is shown the tile | `rolePermissionsConfig` | `roleModelAccess` |

Neither path key falls back to the other, and both default to a naive `model + 's'`. An irregular plural therefore yields a tile pointing at `/countrys` while the route is `/countries`.

**That was already live.** The **OCR Documents tile linked to `/OcrDocuments`, which no router registers** — the route is `/paperless`, set via `pathOverride`. The documents dashboard has been advertising a 404. Same shape as the 6.23.0 tile bug, missed for the same reason: the two halves live in different files under different names.

Eight further entries had camelCase tile links against lowercased routes. Those worked, but only because Express routing is case-insensitive by default — a framework default nobody set on purpose. All now state the path explicitly.

## Also fixed

- **`fieldOrder` orders columns but does not restrict them.** Everything not hidden is appended after it, so the VAT returns table came out 22 columns wide (nine of them VAT boxes) and `countries` grew a stray KashFlow `Id`. All seven now set `strictOrder`, which also stops a field KashFlow *starts* returning from arriving as an unannounced column — `PVABoxTextChangeFrom` did exactly that. The VAT return list is 8 columns; the detail page still shows all 21, via a `fieldOrder` in `CRUDControllerConfig`, which wins in `getMergedConfig`.
- **A filter type that silently filtered nothing.** `applyFilterParams` implements `boolean`, `select`, `daterange` and `numberrange`; anything else renders a control that never applies.

## Deliberately excluded

`product` and `purchaseOrder` are **not** configured, and a test asserts it stays that way. Both return 0 rows from KashFlow on every run — checked across 12 consecutive runs; this business uses neither the product catalogue nor purchase orders — so a tile would advertise a permanently empty page. The models and routes already exist if that changes.

## Tests

`tests/listConfigPaths.test.js` pins route-equals-tile for **every** entry that earns a tile, not just the new ones, plus the read-only grants and the column set. It is not vacuous: run against the unpatched config it produces 30 failures.

Suite **1110 → 1205**, 0 failures, exit 0.

## Notes for review

Two findings recorded in the changelog but **not** fixed here, because they belong upstream in `@cappytech/hcs-schemas`:

- **The `journal` entity does not describe the payload KashFlow returns.** It declares `Id`, `Date`, `Description`, `Lines`; the list endpoint returns none of them (0 of 400 rows have `Id` or `Date`). The real fields survive only because the model is `strict: false`. **`Lines` is not synced at all** — it exists only on the per-journal detail endpoint.
- **`accountingPeriod.IsLocked` does not exist.** 0 of 8 rows carry it; `IsCurrentPeriod` is the real field.

Dates in these collections are `"YYYY-MM-DDTHH:mm:ss"` **strings**, not `Date`s — same cause as the `banktransactions.Date` migration. Sorting works (ISO strings sort chronologically); date-range filters would not, so none are configured.

**Not verified in a browser** — config and unit tests only.

⚠️ Shares version **6.26.0** with #docs/promote-generated-api-operations. Whichever merges second needs renumbering to 6.27.0.