### PR TITLE
Website content editor, and the API hcs-web pulls from (6.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.27.0] - 2026-08-18
+
+### Added
+- **A website content editor at `/website`, and a read-only API the public site pulls from.** Every content file in [hcs-web](https://github.com/CappyTech/hcs-web) — `blogData.js`, `caseStudyData.js`, `servicesData.js`, `accreditationsData.js`, `siteData.js` — carries the same comment: *"Swap this in-memory array for a DB/CMS later without touching the service, controller, or views."* Until now a copy change was a developer, a commit, and a manual deploy in cPanel. The Website Design Brief asks the site to be evidence rather than advertising — real projects, real accreditations, `[TO SUPPLY]` wherever a fact is missing — and the people who can fill those gaps are not the people who can run `git push`.
+
+  **hcs-web is a cache of this data, not a client of it.** It pulls the payload, writes it to disk and serves the public site from that copy, so heroncs.co.uk keeps working with hcs-app switched off entirely — which is what makes it safe to put the company's public site behind a service on a domestic connection. Nothing here should acquire a behaviour that assumes the consumer is live at the moment of a change; the revalidate hook in `webRevalidateService.js` is an optimisation over the consumer's own polling and is deliberately fire-and-forget.
+
+- **A fourth Mongo namespace, `WEB`** (`MONGO_DBNAME_WEB`, default `hcs-webdb`), holding six models: `webCaseStudy`, `webPost`, `webService`, `webAccreditation`, `webSiteSettings` and `webMedia`.
+
+  **The `hcs_app` Mongo user needs `readWrite` + `dbAdmin` on the new database.** It is scoped to `rest-kashflowdb`, `kashflowdb` and `paperless-kashflowdb`; without the grant the app connects and then every write fails `Unauthorized`. That is the step most likely to be missed on deploy, and the symptom does not name the cause.
+
+  `auditPlugin` now attaches to `WEB` as well as `INTERNAL`. It was INTERNAL-only, so a new namespace would have had no audit trail at all — and "who changed this published copy, and when" is the whole point of an editorial trail. The plugin's `sanitize()` already renders Buffers as `[Buffer N bytes]`, so this does not copy every photograph into the audit log.
+
+  **`WEB` is reported by `/healthz` but is not part of `ok`, and is excluded from `maintenanceService.dbState()`.** `mdb.connect()` awaits all four connections, so a misconfigured namespace fails loudly at boot; losing it later must not mark the container unhealthy or 503 CIS, payroll and attendance over marketing copy. The models are also not registered with the generic CRUD/list controllers, which iterate REST and INTERNAL — website content is edited only through `/website`, which owns the draft/publish gate.
+
+- **Draft/publish per record, with publishing on its own route.** `status` is not a form field: `webContentConfig.fields[]` is the write whitelist and the controller builds every update from it, so a record cannot be pushed onto the public internet by adding a hidden input. `publishedAt` is stamped once, on first publication — it is the date the site displays, not a "last touched" timestamp, so fixing a typo does not move an article back to the top of the blog.
+
+- **Images are stored in Mongo, resized on upload.** The storage volume at `~/docker/app/storage` is in **none** of the five nightly backup jobs while Mongo is dumped at 02:00, so bytes in Mongo are backed up, survive a `docker compose pull` redeploy, and need no sixth cron job.
+
+  `sharp` is a new dependency — the app had no image processing of any kind. Uploads are re-encoded to WebP down a ladder that steps **quality first, then dimensions**, because quality alone does not converge: pure noise at the old floor still came out at 634KB against the brief's 300KB ceiling, and foliage, gravel and brickwork — most of what this company photographs — compress much like noise. **EXIF is stripped**, which matters more than it sounds: these photographs are taken on phones on customers' estates, and EXIF carries GPS coordinates. **SVG is rejected**, unlike the letterhead upload it is otherwise modelled on: these bytes are mirrored and served by heroncs.co.uk, and an SVG is a script-bearing document.
+
+### Changed
+- **The Quill initialiser in `layout.ejs` now binds `closest('form')`** rather than the hardcoded `#policy-form`, so any page opting in with `quillEditor: true` works without registering its form id there. It is still **one editor per page** — the `#quill-editor`, `#quill-toolbar` and `#contentHtml-input` ids are hardcoded, and a second instance would silently write into the first one's hidden input, saving one of the two fields empty. `tests/webContentService.test.js` asserts no content type declares more than one `richtext` field.
+
+### Notes
+Three things worth knowing before touching this next.
+
+- **The API is the only route surface in this app that answers without a session.** `"/api/web/"` is in `PUBLIC_PREFIXES`, so everything under it skips `ensureAuthenticated` — the same shape as the `/resources/` prefix that once silently defeated that guard. It is GET-only, token-guarded and rate-limited, and `tests/websiteRoutesGuards.test.js` pins all three plus the prefix itself. A POST added there would inherit the bypass while carrying no CSRF protection.
+- **The token fails closed.** With `WEB_API_TOKEN` unset the endpoint answers 503 rather than serving: an unconfigured deployment that refuses is a problem someone notices, one that answers 200 to the whole internet is not.
+- **The path may not contain `db`, `backup` or `database`, or end `.zip`/`.gz`/`.sql`.** `requestBlocklistService` 403s those *and* counts them toward a one-hour autoban of the caller — which, here, would be the public website.
+
+`scripts/seed-web-content.js --from ~/code/hcs-web` imports the live site's content and its 7.3MB of photographs, idempotent by slug and by image hash, so the editor opens on the real site rather than an empty one. It takes a path rather than bundling a fixture, so the photographs are not carried in every image build for the sake of a script that runs once.
+
 ## [6.26.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to hcs-app will be documented here. Format follows [Keep a C
 
 ## [6.27.0] - 2026-08-18
 
-### Added
-- **A website content editor at `/website`, and a read-only API the public site pulls from.** Every content file in [hcs-web](https://github.com/CappyTech/hcs-web) — `blogData.js`, `caseStudyData.js`, `servicesData.js`, `accreditationsData.js`, `siteData.js` — carries the same comment: *"Swap this in-memory array for a DB/CMS later without touching the service, controller, or views."* Until now a copy change was a developer, a commit, and a manual deploy in cPanel. The Website Design Brief asks the site to be evidence rather than advertising — real projects, real accreditations, `[TO SUPPLY]` wherever a fact is missing — and the people who can fill those gaps are not the people who can run `git push`.
+[#79](https://github.com/CappyTech/hcs-app/pull/79) · pairs with [hcs-web#7](https://github.com/CappyTech/hcs-web/pull/7)
 
-  **hcs-web is a cache of this data, not a client of it.** It pulls the payload, writes it to disk and serves the public site from that copy, so heroncs.co.uk keeps working with hcs-app switched off entirely — which is what makes it safe to put the company's public site behind a service on a domestic connection. Nothing here should acquire a behaviour that assumes the consumer is live at the moment of a change; the revalidate hook in `webRevalidateService.js` is an optimisation over the consumer's own polling and is deliberately fire-and-forget.
+### Added
+- **A website content editor at `/website`, and a read-only API the public site pulls from.** Every content file in [hcs-web](https://github.com/CappyTech/hcs-web) — `blogData.js`, `caseStudyData.js`, `servicesData.js`, `accreditationsData.js`, `siteData.js` — carries the same comment: *"Swap this in-memory array for a DB/CMS later without touching the service, controller, or views."* Until now a copy change was a developer, a commit, and a manual **Update from Remote → Deploy HEAD Commit** in cPanel. The Website Design Brief asks the site to be evidence rather than advertising — real projects, real accreditations, `[TO SUPPLY]` wherever a fact is missing — and the people who can fill those gaps are not the people who can run `git push`.
+
+  **hcs-web is a cache of this data, not a client of it.** It pulls the payload, writes it to disk and serves the public site from that copy, so heroncs.co.uk keeps working with hcs-app switched off entirely — which is what makes it safe to put the company's public site behind a service on a domestic connection. hcs-app being reachable governs *editing*, never *serving*. Nothing here should acquire a behaviour that assumes the consumer is live at the moment of a change; the revalidate hook in `webRevalidateService.js` is an optimisation over the consumer's own polling and is deliberately fire-and-forget.
 
 - **A fourth Mongo namespace, `WEB`** (`MONGO_DBNAME_WEB`, default `hcs-webdb`), holding six models: `webCaseStudy`, `webPost`, `webService`, `webAccreditation`, `webSiteSettings` and `webMedia`.
 
   **The `hcs_app` Mongo user needs `readWrite` + `dbAdmin` on the new database.** It is scoped to `rest-kashflowdb`, `kashflowdb` and `paperless-kashflowdb`; without the grant the app connects and then every write fails `Unauthorized`. That is the step most likely to be missed on deploy, and the symptom does not name the cause.
 
   `auditPlugin` now attaches to `WEB` as well as `INTERNAL`. It was INTERNAL-only, so a new namespace would have had no audit trail at all — and "who changed this published copy, and when" is the whole point of an editorial trail. The plugin's `sanitize()` already renders Buffers as `[Buffer N bytes]`, so this does not copy every photograph into the audit log.
-
-  **`WEB` is reported by `/healthz` but is not part of `ok`, and is excluded from `maintenanceService.dbState()`.** `mdb.connect()` awaits all four connections, so a misconfigured namespace fails loudly at boot; losing it later must not mark the container unhealthy or 503 CIS, payroll and attendance over marketing copy. The models are also not registered with the generic CRUD/list controllers, which iterate REST and INTERNAL — website content is edited only through `/website`, which owns the draft/publish gate.
 
 - **Draft/publish per record, with publishing on its own route.** `status` is not a form field: `webContentConfig.fields[]` is the write whitelist and the controller builds every update from it, so a record cannot be pushed onto the public internet by adding a hidden input. `publishedAt` is stamped once, on first publication — it is the date the site displays, not a "last touched" timestamp, so fixing a typo does not move an article back to the top of the blog.
 
@@ -24,6 +24,8 @@ All notable changes to hcs-app will be documented here. Format follows [Keep a C
   `sharp` is a new dependency — the app had no image processing of any kind. Uploads are re-encoded to WebP down a ladder that steps **quality first, then dimensions**, because quality alone does not converge: pure noise at the old floor still came out at 634KB against the brief's 300KB ceiling, and foliage, gravel and brickwork — most of what this company photographs — compress much like noise. **EXIF is stripped**, which matters more than it sounds: these photographs are taken on phones on customers' estates, and EXIF carries GPS coordinates. **SVG is rejected**, unlike the letterhead upload it is otherwise modelled on: these bytes are mirrored and served by heroncs.co.uk, and an SVG is a script-bearing document.
 
 ### Changed
+- **`WEB` is reported by `/healthz` but is not part of `ok`, and is excluded from `maintenanceService.dbState()`.** `mdb.connect()` awaits all four connections, so a misconfigured namespace fails loudly at boot; losing it later must not mark the container unhealthy or 503 CIS, payroll and attendance over marketing copy. The models are also not registered with the generic CRUD/list controllers, which iterate REST and INTERNAL — website content is edited only through `/website`, which owns the draft/publish gate.
+
 - **The Quill initialiser in `layout.ejs` now binds `closest('form')`** rather than the hardcoded `#policy-form`, so any page opting in with `quillEditor: true` works without registering its form id there. It is still **one editor per page** — the `#quill-editor`, `#quill-toolbar` and `#contentHtml-input` ids are hardcoded, and a second instance would silently write into the first one's hidden input, saving one of the two fields empty. `tests/webContentService.test.js` asserts no content type declares more than one `richtext` field.
 
 ### Notes
@@ -34,6 +36,24 @@ Three things worth knowing before touching this next.
 - **The path may not contain `db`, `backup` or `database`, or end `.zip`/`.gz`/`.sql`.** `requestBlocklistService` 403s those *and* counts them toward a one-hour autoban of the caller — which, here, would be the public website.
 
 `scripts/seed-web-content.js --from ~/code/hcs-web` imports the live site's content and its 7.3MB of photographs, idempotent by slug and by image hash, so the editor opens on the real site rather than an empty one. It takes a path rather than bundling a fixture, so the photographs are not carried in every image build for the sake of a script that runs once.
+
+### Verification
+Run against a throwaway `mongo:8.0`, never the production database.
+
+- **1285 tests pass**, up from 1205 — new coverage for the route guards, the payload, the image pipeline, and every view at every declared field.
+- The seed imported the live site whole: 10 images, 2 case studies, 1 post, 6 services, 5 accreditations, site settings. `Living wage LOGO.png` came down from 321KB to 90KB.
+- The API answered 401 without a token, 200 with, 304 on a matching ETag, and carried no image bytes in the manifest.
+- **Unpublishing a case study removed it from the payload** on the next request.
+- hcs-web pulled it and rendered every page; **with this app killed and hcs-web restarted, every page still rendered, images included**, from its disk mirror. Deleting the mirror fell through to the seed arrays.
+
+### Deploying
+1. Grant the Mongo user `readWrite` + `dbAdmin` on `hcs-webdb` (above).
+2. `MONGO_DBNAME_WEB` and `WEB_API_TOKEN` in `docker/app/compose.env` — `env_file:` vars need `docker compose up -d`, not `restart`.
+3. Deploy, then check the log for the WEB connection opening and no `Unauthorized`.
+4. `node scripts/seed-web-content.js --from ~/code/hcs-web` once.
+5. Then the hcs-web side.
+
+hcs-web is safe to deploy at any point: with no token or no API it serves its built-in seed content, which is what the site shows today. There is no window where the public site is broken.
 
 ## [6.26.0] - 2026-08-18
 

--- a/app.js
+++ b/app.js
@@ -86,6 +86,8 @@ import __gdprRoutes from './mongoose/routes/gdprRoutes.js';
 import __legalRoutes from './mongoose/routes/legalRoutes.js';
 import __companyDocsRoutes from './mongoose/routes/companyDocsRoutes.js';
 import __auditRoutes from './mongoose/routes/auditRoutes.js';
+import __webRoutes from './mongoose/routes/webRoutes.js';
+import __webApiRoutes from './mongoose/routes/webApiRoutes.js';
 import __errorHandlerService from './services/errorHandlerService.js';
 import __webSocketService from './mongoose/services/webSocketService.js';
 import __jobRegistry from './mongoose/services/jobRegistry.js';
@@ -197,11 +199,17 @@ const main = async () => {
       const restReady = mdb.REST?.connection?.readyState === 1;
       const internalReady = mdb.INTERNAL?.connection?.readyState === 1;
       const paperlessReady = mdb.PAPERLESS?.connection?.readyState === 1;
+      // WEB holds the public website's copy and is reported but deliberately
+      // NOT part of `ok`. mdb.connect() awaits all four, so a misconfigured WEB
+      // namespace fails loudly at boot; losing it later must not mark the
+      // container unhealthy and restart CIS, payroll and attendance over
+      // marketing content. Same reasoning in maintenanceService.dbState().
+      const webReady = mdb.WEB?.connection?.readyState === 1;
       const ok = restReady && internalReady && paperlessReady;
       res.status(ok ? 200 : 503).json({
         ok,
         uptime: process.uptime(),
-        db: { REST: restReady, INTERNAL: internalReady, PAPERLESS: paperlessReady },
+        db: { REST: restReady, INTERNAL: internalReady, PAPERLESS: paperlessReady, WEB: webReady },
       });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -548,6 +556,11 @@ const main = async () => {
     appRouter.use('/', __legalRoutes);
     appRouter.use('/', __companyDocsRoutes);
     appRouter.use('/', __auditRoutes);
+    appRouter.use('/', __webRoutes);
+    // Read-only content API for hcs-web. Inside appRouter so it gets body
+    // parsing, request logging and maintenance's JSON 503; exempted from the
+    // session guard by the "/api/web/" prefix in authService's PUBLIC_PREFIXES.
+    appRouter.use('/', __webApiRoutes);
 
     // Catch-all 404
     appRouter.use((req, res, next) => {

--- a/compose.env.example
+++ b/compose.env.example
@@ -210,6 +210,13 @@ MONGO_DBNAME_INTERNAL=internal
 MONGO_DBNAME_PAPERLESS=paperless
 # used by: `mongoose/services/mongooseDatabaseService.js` (REST models) # required
 MONGO_DBNAME_REST=rest
+# used by: `mongoose/services/mongooseDatabaseService.js` (WEB models — the
+# public website's content, edited at /website and pulled by hcs-web) # required
+#
+# The Mongo user in MONGO_USER needs readWrite + dbAdmin on this database, the
+# same as it has on the other three. Without the grant the app connects and then
+# every write fails Unauthorized.
+MONGO_DBNAME_WEB=hcs-webdb
 # used by: `mongoose/services/mongooseDatabaseService.js` (host for all connections) # required
 MONGO_HOST=host.docker.internal
 # used by: `mongoose/services/mongooseDatabaseService.js` (password when auth enabled) # required
@@ -361,3 +368,21 @@ DEBUG=true
 ########################################
 # used by: `services/peoplesPensionService.js` — set to enable direct API upload (optional)
 # PEOPLES_PENSION_API_KEY=
+
+########################################
+# Website content API (hcs-web)
+########################################
+# used by: `mongoose/controllers/webApiController.js` (bearer token on /api/web/*) # required for the public site
+#
+# hcs-web sends this as `Authorization: Bearer <token>`. The content behind it is
+# public by definition — it is the company website — so this is a throttle, not
+# confidentiality: without it the endpoint is an open invitation to scrape a
+# domestic connection through the frp tunnel. Unset, the API answers 503 rather
+# than serving, which is deliberate: an unconfigured deployment must refuse.
+WEB_API_TOKEN=
+# used by: `services/webRevalidateService.js` (tell hcs-web to re-pull now) # optional
+#
+# Both optional. Unset, publishing still reaches the site — hcs-web polls — it
+# just takes until the next poll rather than a second or two.
+WEB_REVALIDATE_URL=https://heroncs.co.uk/revalidate
+WEB_REVALIDATE_SECRET=

--- a/mongoose/config/dashboardTilesConfig.js
+++ b/mongoose/config/dashboardTilesConfig.js
@@ -298,6 +298,50 @@ export default {
         buttonClass: 'bg-green-700 hover:bg-green-800'
     },
 
+    // ── Website ───────────────────────────────────────────────────────
+    WebsiteCaseStudies: {
+        title: 'Case Studies',
+        description: 'Project stories published at heroncs.co.uk/studies.',
+        link: '/website/case-studies',
+        department: ['website'],
+        buttonClass: 'bg-green-700 hover:bg-green-800'
+    },
+    WebsitePosts: {
+        title: 'Blog Posts',
+        description: 'News and updates published at heroncs.co.uk/blog.',
+        link: '/website/posts',
+        department: ['website'],
+        buttonClass: 'bg-green-700 hover:bg-green-800'
+    },
+    WebsiteServices: {
+        title: 'Services',
+        description: 'The service cards on heroncs.co.uk/services.',
+        link: '/website/services',
+        department: ['website'],
+        buttonClass: 'bg-green-700 hover:bg-green-800'
+    },
+    WebsiteAccreditations: {
+        title: 'Accreditations',
+        description: 'Accreditation logos and registration details.',
+        link: '/website/accreditations',
+        department: ['website'],
+        buttonClass: 'bg-green-700 hover:bg-green-800'
+    },
+    WebsiteMedia: {
+        title: 'Media Library',
+        description: 'Photographs used across the public website.',
+        link: '/website/media',
+        department: ['website'],
+        buttonClass: 'bg-blue-700 hover:bg-blue-800'
+    },
+    WebsiteSettings: {
+        title: 'Site Settings',
+        description: 'Company details, contact information and SEO defaults.',
+        link: '/website/settings',
+        department: ['website'],
+        buttonClass: 'bg-gray-700 hover:bg-gray-800'
+    },
+
     // ── Management ────────────────────────────────────────────────────
     ExternalOneDrive: {
         title: 'Microsoft OneDrive',

--- a/mongoose/config/departmentsConfig.js
+++ b/mongoose/config/departmentsConfig.js
@@ -105,6 +105,17 @@ export default {
     icon: 'bi-calendar-check',
     roles: ['admin', 'employee', 'subcontractor'],
   },
+  website: {
+    // Authoring surface for the public site at heroncs.co.uk (hcs-web).
+    //
+    // Admin only, and deliberately not folded into 'management': what is
+    // published here is read by the whole internet, so the set of people who
+    // can change it should be named rather than inherited.
+    title: 'Website',
+    navLabel: 'Website',
+    icon: 'bi-globe',
+    roles: ['admin'],
+  },
   create: {
     title: 'Create',
     navLabel: 'Create',

--- a/mongoose/config/rolePermissionsConfig.js
+++ b/mongoose/config/rolePermissionsConfig.js
@@ -182,6 +182,15 @@ const routeAccess = {
   // are enforced by the adminGuard on those routes in bankRoutes.js.
   '/bank':                ['admin', 'accountant'],
 
+  // Website content editor. Same longest-prefix rule as '/bank': one entry
+  // covers the whole module.
+  //
+  // The public content API is NOT listed here on purpose. routeAccess is only
+  // consulted for a request that already has req.user, and that API is read by
+  // hcs-web with a bearer token and no session at all — an entry here would
+  // govern nothing. Its guard is the token check in webApiRoutes.js.
+  '/website':             ['admin'],
+
   // Read-only accountant portal. Same longest-prefix rule as '/bank' above, so
   // this one entry covers the whole surface.
   //

--- a/mongoose/config/webContentConfig.js
+++ b/mongoose/config/webContentConfig.js
@@ -1,0 +1,155 @@
+/**
+ * The registry for the website content editor at /website.
+ *
+ * One entry per content type. Routes, list columns, form fields and the write
+ * whitelist all derive from here, so adding a field to the public site is a
+ * declaration rather than an edit in five places — the same config-driven habit
+ * as listControllerConfig.js, and for the same reason: the failure mode of the
+ * alternative is a field that exists in the model, renders in the form, and is
+ * silently dropped on save because one list was not updated.
+ *
+ * **The `fields` array is the write whitelist.** webController builds every
+ * update from it and ignores anything else in the body, so a field that is not
+ * declared here cannot be written through the editor at all.
+ *
+ * Field types are rendered by views/tailwindcss/website/_field.ejs:
+ *
+ *   text · textarea · richtext · number · date · url · tags
+ *   image    — a media picker: { media, alt }
+ *   panel    — image plus a caption: { media, alt, caption }
+ *   gallery  — repeating panels
+ *   hours    — repeating { days, time }
+ *   offices  — repeating { label, phone, address{line1..4, postcode} }
+ *
+ * Exactly **one `richtext` field per type** is allowed, because the Quill
+ * initialiser in layout.ejs binds hardcoded element ids (#quill-editor,
+ * #contentHtml-input) and a second instance on the page would write into the
+ * first one's hidden input. tests/webContentConfig.test.js pins this.
+ */
+
+const webContentConfig = {
+  'case-studies': {
+    model: 'webCaseStudy',
+    label: 'Case Study',
+    plural: 'Case Studies',
+    icon: 'bi-buildings',
+    // Where this appears on the public site, shown in the editor so the person
+    // writing knows what they are affecting.
+    publicPath: '/studies/:slug',
+    listColumns: ['title', 'client', 'location', 'status'],
+    defaultSort: { sortOrder: 1, title: 1 },
+    fields: [
+      { name: 'title', type: 'text', label: 'Title', required: true },
+      { name: 'slug', type: 'text', label: 'Slug', help: 'Left blank, this is generated from the title. Changing it changes the public URL.' },
+      { name: 'client', type: 'text', label: 'Client', help: 'Leave blank until they have agreed to be named.' },
+      { name: 'location', type: 'text', label: 'Location' },
+      { name: 'scope', type: 'textarea', label: 'Scope of works' },
+      { name: 'excerpt', type: 'textarea', label: 'Excerpt', help: 'One or two lines, shown on the index card.' },
+      { name: 'card', type: 'image', label: 'Card image' },
+      { name: 'before', type: 'panel', label: 'Before' },
+      { name: 'after', type: 'panel', label: 'After' },
+      { name: 'gallery', type: 'gallery', label: 'Gallery' },
+      { name: 'contentHtml', type: 'richtext', label: 'Full write-up' },
+      { name: 'socialValue', type: 'textarea', label: 'Social value note' },
+      { name: 'sortOrder', type: 'number', label: 'Sort order' },
+    ],
+  },
+
+  posts: {
+    model: 'webPost',
+    label: 'Blog Post',
+    plural: 'Blog Posts',
+    icon: 'bi-newspaper',
+    publicPath: '/blog/:slug',
+    listColumns: ['title', 'author', 'publishedAt', 'status'],
+    defaultSort: { publishedAt: -1, createdAt: -1 },
+    fields: [
+      { name: 'title', type: 'text', label: 'Title', required: true },
+      { name: 'slug', type: 'text', label: 'Slug' },
+      { name: 'excerpt', type: 'textarea', label: 'Excerpt' },
+      { name: 'contentHtml', type: 'richtext', label: 'Post' },
+      { name: 'author', type: 'text', label: 'Byline' },
+      { name: 'tags', type: 'tags', label: 'Tags', help: 'Comma separated.' },
+    ],
+  },
+
+  services: {
+    model: 'webService',
+    label: 'Service',
+    plural: 'Services',
+    icon: 'bi-tools',
+    publicPath: '/services',
+    listColumns: ['title', 'href', 'status'],
+    defaultSort: { sortOrder: 1, title: 1 },
+    fields: [
+      { name: 'title', type: 'text', label: 'Title', required: true },
+      { name: 'slug', type: 'text', label: 'Slug' },
+      { name: 'description', type: 'textarea', label: 'Description' },
+      { name: 'image', type: 'image', label: 'Card image' },
+      {
+        name: 'href', type: 'text', label: 'Links to',
+        help: 'Anything other than /contact means this service has its own page — which is also what upgrades its link in the site footer.',
+      },
+      { name: 'cta', type: 'text', label: 'Button label' },
+      { name: 'pageTitle', type: 'text', label: 'Page title (SEO)' },
+      { name: 'metaDescription', type: 'textarea', label: 'Meta description (SEO)' },
+      { name: 'contentHtml', type: 'richtext', label: 'Page content' },
+      { name: 'sortOrder', type: 'number', label: 'Sort order' },
+    ],
+  },
+
+  accreditations: {
+    model: 'webAccreditation',
+    label: 'Accreditation',
+    plural: 'Accreditations',
+    icon: 'bi-patch-check',
+    publicPath: '/accreditations',
+    listColumns: ['name', 'membershipNumber', 'validTo', 'status'],
+    defaultSort: { sortOrder: 1, name: 1 },
+    fields: [
+      { name: 'name', type: 'text', label: 'Name', required: true },
+      { name: 'slug', type: 'text', label: 'Slug' },
+      { name: 'logo', type: 'image', label: 'Logo' },
+      { name: 'description', type: 'textarea', label: 'Description' },
+      { name: 'membershipNumber', type: 'text', label: 'Membership / registration number', help: 'Procurement teams ask for this.' },
+      { name: 'validFrom', type: 'date', label: 'Valid from' },
+      { name: 'validTo', type: 'date', label: 'Valid to' },
+      { name: 'certificateUrl', type: 'url', label: 'Certificate link' },
+      { name: 'sortOrder', type: 'number', label: 'Sort order' },
+    ],
+  },
+
+  settings: {
+    model: 'webSiteSettings',
+    label: 'Site Settings',
+    plural: 'Site Settings',
+    icon: 'bi-sliders',
+    publicPath: '/',
+    // A singleton, found by key: 'site'. There is no list and no create — the
+    // routes for those are not registered.
+    singleton: true,
+    fields: [
+      { name: 'name', type: 'text', label: 'Company name', required: true },
+      { name: 'email', type: 'text', label: 'Contact email' },
+      { name: 'tagline', type: 'text', label: 'Tagline' },
+      { name: 'companyNumber', type: 'text', label: 'Company number', help: 'Statutory disclosure — must appear on the site.' },
+      { name: 'registrationCountry', type: 'text', label: 'Registered in' },
+      { name: 'companyType', type: 'text', label: 'Company type' },
+      { name: 'vatNumber', type: 'text', label: 'VAT number' },
+      { name: 'offices', type: 'offices', label: 'Offices' },
+      { name: 'hours', type: 'hours', label: 'Opening hours' },
+      { name: 'inboxMonitored', type: 'text', label: 'Inbox — monitoring note' },
+      { name: 'inboxResponse', type: 'text', label: 'Inbox — response time note' },
+      { name: 'ogImage', type: 'image', label: 'Social share image', help: '1200×630. Empty means the share tag is omitted rather than pointing at a missing file.' },
+      { name: 'robots', type: 'text', label: 'robots' },
+      { name: 'themeColor', type: 'text', label: 'Theme colour' },
+      { name: 'locale', type: 'text', label: 'Locale' },
+      { name: 'twitterHandle', type: 'text', label: 'X / Twitter handle' },
+      { name: 'instagramHandle', type: 'text', label: 'Instagram handle' },
+      { name: 'facebookHandle', type: 'text', label: 'Facebook handle' },
+      { name: 'linkedinHandle', type: 'text', label: 'LinkedIn handle' },
+    ],
+  },
+};
+
+export default webContentConfig;

--- a/mongoose/controllers/webApiController.js
+++ b/mongoose/controllers/webApiController.js
@@ -1,0 +1,108 @@
+/**
+ * The read-only content API that hcs-web pulls from.
+ *
+ * hcs-web keeps a durable mirror of what this returns and serves heroncs.co.uk
+ * from that copy, so this endpoint being unreachable slows publishing down —
+ * it never takes the public site off the air. Nothing here should acquire a
+ * behaviour that assumes the consumer is live at the moment of a change.
+ *
+ * There is no write surface at all, by design. Publishing happens in the editor
+ * at /website, behind a session and an audit trail; if a POST ever appears here
+ * it needs CSRF handling that this router deliberately does not have.
+ */
+import crypto from 'crypto';
+import mdb from '../services/mongooseDatabaseService.js';
+import logger from '../../services/loggerService.js';
+import { buildPayload, payloadEtag } from '../../services/webContentService.js';
+
+/** Timing-safe compare over hashes, so lengths never leak. */
+function safeEqual(a, b) {
+  const ha = crypto.createHash('sha256').update(String(a)).digest();
+  const hb = crypto.createHash('sha256').update(String(b)).digest();
+  return crypto.timingSafeEqual(ha, hb);
+}
+
+/**
+ * Bearer-token guard.
+ *
+ * The content behind it is public by definition — it is the company website.
+ * The token is not confidentiality, it is a throttle: without it this endpoint
+ * is an open invitation to scrape a residential connection through the frp
+ * tunnel, and the media route serves image bytes.
+ *
+ * Fails **closed** when WEB_API_TOKEN is unset. An unconfigured deployment
+ * answering 503 is a problem someone notices; one that answers 200 to the whole
+ * internet is not.
+ */
+export function requireWebApiToken(req, res, next) {
+  const expected = String(process.env.WEB_API_TOKEN || '').trim();
+  if (!expected) {
+    logger.error('[webApi] WEB_API_TOKEN not configured — the content API is disabled');
+    return res.status(503).json({ error: 'Content API not configured' });
+  }
+  const header = String(req.headers.authorization || '');
+  const provided = header.startsWith('Bearer ') ? header.slice(7).trim() : '';
+  if (!provided || !safeEqual(expected, provided)) {
+    logger.warn('[webApi] rejected request with missing or invalid token', { path: req.path });
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  return next();
+}
+
+/**
+ * GET /api/web/content — every published record, in one document.
+ *
+ * The ETag is a hash of the content itself (see payloadEtag), so a poll that
+ * finds nothing changed costs a 304 with no body. `no-cache` rather than
+ * `no-store`: the consumer is expected to keep this and revalidate, which is
+ * the whole point of the mirror.
+ */
+export const getContent = async (req, res, next) => {
+  try {
+    const payload = await buildPayload();
+    const etag = payloadEtag(payload);
+
+    res.set('ETag', etag);
+    res.set('Cache-Control', 'no-cache');
+
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end();
+    }
+    return res.json(payload);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+/**
+ * GET /api/web/media/:uuid — the bytes of one published image.
+ *
+ * Immutable caching is safe because the editor never rewrites an image in
+ * place: a re-upload creates a new record with a new uuid. The ETag is the
+ * content hash the manifest already published, so the consumer can tell whether
+ * it needs the body before asking for it.
+ */
+export const getMedia = async (req, res, next) => {
+  try {
+    const doc = await mdb.WEB.webMedia.findOne({ uuid: String(req.params.uuid), status: 'published' }).lean();
+    if (!doc || !doc.bytes) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const etag = `"${doc.hash}"`;
+    res.set('ETag', etag);
+    res.set('Cache-Control', 'public, max-age=31536000, immutable');
+    res.set('Content-Type', doc.mime);
+    // Stops a browser sniffing these bytes into something executable.
+    res.set('X-Content-Type-Options', 'nosniff');
+
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end();
+    }
+    return res.send(Buffer.from(doc.bytes.buffer || doc.bytes));
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export default { requireWebApiToken, getContent, getMedia };

--- a/mongoose/controllers/webController.js
+++ b/mongoose/controllers/webController.js
@@ -1,0 +1,456 @@
+/**
+ * The website content editor at /website.
+ *
+ * Generic over webContentConfig.js: every collection type shares one list view
+ * and one form view, and the config is the write whitelist — a body field that
+ * is not declared there is not written. That is what keeps `status` out of
+ * reach of a hand-rolled POST: publishing is its own route, so a record cannot
+ * be pushed onto the public internet by adding a hidden input to a form.
+ *
+ * contentHtml is pre-sanitised by the global xssSanitize middleware
+ * (securityService.js RICH_TEXT_FIELDS), exactly as company-docs relies on.
+ * No second filterXSS call here.
+ */
+import multer from 'multer';
+import mdb from '../services/mongooseDatabaseService.js';
+import logger from '../../services/loggerService.js';
+import csrfService from '../../services/csrfService.js';
+import webContentConfig from '../config/webContentConfig.js';
+import { slugify } from '../../services/webContentService.js';
+import webMediaService from '../../services/webMediaService.js';
+import { notifyWebRevalidate } from '../../services/webRevalidateService.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function typeOr404(type) {
+  const cfg = webContentConfig[type];
+  if (!cfg) {
+    throw Object.assign(new Error('Unknown content type'), { statusCode: 404 });
+  }
+  return cfg;
+}
+
+function modelFor(cfg) {
+  return mdb.WEB[cfg.model];
+}
+
+/** The field that names a record: most types use `title`, accreditations `name`. */
+function titleField(cfg) {
+  return cfg.fields.some((f) => f.name === 'title') ? 'title' : 'name';
+}
+
+function str(v) {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+/** Form arrays arrive as { '0': {...}, '1': {...} } or a real array. Normalise. */
+function toArray(v) {
+  if (Array.isArray(v)) return v;
+  if (v && typeof v === 'object') return Object.keys(v).sort((a, b) => Number(a) - Number(b)).map((k) => v[k]);
+  return [];
+}
+
+function imageFrom(v) {
+  return { media: str(v?.media), alt: str(v?.alt) };
+}
+
+function panelFrom(v) {
+  return { ...imageFrom(v), caption: str(v?.caption) };
+}
+
+/**
+ * Build a mongo update from the body, driven entirely by the config.
+ *
+ * Anything not declared in cfg.fields is ignored — including `status`,
+ * `publishedAt`, `uuid` and the audit stamps, none of which a form may set.
+ */
+function updateFromBody(cfg, body) {
+  const update = {};
+  for (const field of cfg.fields) {
+    const raw = body[field.name];
+    if (raw === undefined) continue;
+    switch (field.type) {
+      case 'number':
+        update[field.name] = Number.isFinite(Number(raw)) ? Number(raw) : 0;
+        break;
+      case 'date':
+        update[field.name] = str(raw) ? new Date(str(raw)) : null;
+        break;
+      case 'tags':
+        update[field.name] = str(raw).split(',').map((t) => t.trim()).filter(Boolean);
+        break;
+      case 'image':
+        update[field.name] = imageFrom(raw);
+        break;
+      case 'panel':
+        update[field.name] = panelFrom(raw);
+        break;
+      case 'gallery':
+        update[field.name] = toArray(raw).map(panelFrom).filter((g) => g.media);
+        break;
+      case 'hours':
+        update[field.name] = toArray(raw)
+          .map((h) => ({ days: str(h?.days), time: str(h?.time) }))
+          .filter((h) => h.days || h.time);
+        break;
+      case 'offices':
+        update[field.name] = toArray(raw)
+          .map((o) => ({
+            label: str(o?.label),
+            phone: str(o?.phone),
+            address: {
+              line1: str(o?.address?.line1),
+              line2: str(o?.address?.line2),
+              line3: str(o?.address?.line3),
+              line4: str(o?.address?.line4),
+              postcode: str(o?.address?.postcode),
+            },
+          }))
+          .filter((o) => o.label || o.phone || o.address.line1);
+        break;
+      case 'richtext':
+        // Already sanitised globally; stored as-is.
+        update[field.name] = typeof raw === 'string' ? raw : '';
+        break;
+      default:
+        update[field.name] = str(raw);
+    }
+  }
+  return update;
+}
+
+/**
+ * A slug that is unique within the collection.
+ *
+ * Generated from the title when the field is left blank, which is the normal
+ * case — the slug is the public URL, and asking someone writing a case study to
+ * invent one is how you end up with "case-study-final-2".
+ */
+async function uniqueSlug(cfg, Model, desired, fallbackFrom, excludeUuid) {
+  const base = slugify(desired || fallbackFrom) || 'untitled';
+  let candidate = base;
+  for (let n = 2; n < 100; n += 1) {
+    const clash = await Model.findOne({ slug: candidate, ...(excludeUuid ? { uuid: { $ne: excludeUuid } } : {}) })
+      .select('uuid').lean();
+    if (!clash) return candidate;
+    candidate = `${base}-${n}`;
+  }
+  return `${base}-${Date.now()}`;
+}
+
+/** Media the pickers offer. Metadata only — never the bytes. */
+async function mediaChoices() {
+  return mdb.WEB.webMedia.find({}).select('-bytes').sort({ createdAt: -1 }).lean();
+}
+
+// ── Collection types ─────────────────────────────────────────────────────────
+
+export const getList = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    if (cfg.singleton) return res.redirect('/website/settings');
+    const records = await modelFor(cfg).find({}).select('-bytes').sort(cfg.defaultSort || { createdAt: -1 }).lean();
+    res.render('tailwindcss/website/list', {
+      title: cfg.plural,
+      type: req.params.type,
+      cfg,
+      records,
+      titleField: titleField(cfg),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getCreate = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    res.render('tailwindcss/website/form', {
+      title: `New ${cfg.label}`,
+      type: req.params.type,
+      cfg,
+      record: null,
+      media: await mediaChoices(),
+      // Loads Quill in layout.ejs. See webContentConfig's header for why there
+      // is never more than one richtext field on a page.
+      quillEditor: cfg.fields.some((f) => f.type === 'richtext'),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const postCreate = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    const Model = modelFor(cfg);
+    const update = updateFromBody(cfg, req.body);
+    update.slug = await uniqueSlug(cfg, Model, update.slug, update[titleField(cfg)]);
+    update.createdBy = req.user?._id;
+    update.updatedBy = req.user?._id;
+    const created = await Model.create(update);
+    req.flash('success', `${cfg.label} created as a draft. Publish it when it is ready.`);
+    res.redirect(`/website/${req.params.type}/${created.uuid}/edit`);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getEdit = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    const record = await modelFor(cfg).findOne({ uuid: req.params.uuid }).lean();
+    if (!record) {
+      return next(Object.assign(new Error(`${cfg.label} not found`), { statusCode: 404 }));
+    }
+    res.render('tailwindcss/website/form', {
+      title: record[titleField(cfg)] || cfg.label,
+      type: req.params.type,
+      cfg,
+      record,
+      media: await mediaChoices(),
+      quillEditor: cfg.fields.some((f) => f.type === 'richtext'),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const postEdit = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    const Model = modelFor(cfg);
+    const existing = await Model.findOne({ uuid: req.params.uuid }).select('uuid slug status').lean();
+    if (!existing) {
+      return next(Object.assign(new Error(`${cfg.label} not found`), { statusCode: 404 }));
+    }
+    const update = updateFromBody(cfg, req.body);
+    update.slug = await uniqueSlug(cfg, Model, update.slug, update[titleField(cfg)], existing.uuid);
+    update.updatedBy = req.user?._id;
+    await Model.updateOne({ uuid: existing.uuid }, { $set: update });
+
+    // A published record has just changed what the public site shows.
+    if (existing.status === 'published') notifyWebRevalidate('content updated');
+
+    req.flash('success', `${cfg.label} saved.`);
+    res.redirect(`/website/${req.params.type}/${existing.uuid}/edit`);
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * Publish / unpublish.
+ *
+ * Its own route rather than a field on the form, so that putting something in
+ * front of the public needs a deliberate act. publishedAt is stamped once, on
+ * the first publication: it is the date the site displays, not a "last touched"
+ * timestamp, and re-publishing after a typo fix should not move an article back
+ * to the top of the blog.
+ */
+export const postPublish = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    const Model = modelFor(cfg);
+    const record = await Model.findOne({ uuid: req.params.uuid }).select('uuid publishedAt').lean();
+    if (!record) {
+      return next(Object.assign(new Error(`${cfg.label} not found`), { statusCode: 404 }));
+    }
+    await Model.updateOne({ uuid: record.uuid }, {
+      $set: {
+        status: 'published',
+        publishedAt: record.publishedAt || new Date(),
+        updatedBy: req.user?._id,
+      },
+    });
+    notifyWebRevalidate(`${cfg.label} published`);
+    req.flash('success', `${cfg.label} published. The website updates within a minute.`);
+    res.redirect(`/website/${req.params.type}/${record.uuid}/edit`);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const postUnpublish = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    await modelFor(cfg).updateOne(
+      { uuid: req.params.uuid },
+      { $set: { status: 'draft', updatedBy: req.user?._id } },
+    );
+    notifyWebRevalidate(`${cfg.label} unpublished`);
+    req.flash('success', `${cfg.label} unpublished and back to draft.`);
+    res.redirect(`/website/${req.params.type}/${req.params.uuid}/edit`);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const postDelete = async (req, res, next) => {
+  try {
+    const cfg = typeOr404(req.params.type);
+    if (cfg.singleton) {
+      return next(Object.assign(new Error('Site settings cannot be deleted'), { statusCode: 400 }));
+    }
+    const record = await modelFor(cfg).findOne({ uuid: req.params.uuid }).select('uuid status').lean();
+    if (record) {
+      await modelFor(cfg).deleteOne({ uuid: record.uuid });
+      if (record.status === 'published') notifyWebRevalidate(`${cfg.label} deleted`);
+    }
+    req.flash('success', `${cfg.label} deleted.`);
+    res.redirect(`/website/${req.params.type}`);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ── Site settings (singleton) ────────────────────────────────────────────────
+
+export const getSettings = async (req, res, next) => {
+  try {
+    const cfg = webContentConfig.settings;
+    const record = await mdb.WEB.webSiteSettings.findOne({ key: 'site' }).lean();
+    res.render('tailwindcss/website/form', {
+      title: 'Site Settings',
+      type: 'settings',
+      cfg,
+      record,
+      media: await mediaChoices(),
+      quillEditor: false,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const postSettings = async (req, res, next) => {
+  try {
+    const cfg = webContentConfig.settings;
+    const update = updateFromBody(cfg, req.body);
+    update.updatedBy = req.user?._id;
+    // Upsert on the singleton key. slug is unused here but the schema declares
+    // uuid unique, so $setOnInsert lets mongoose supply the default.
+    await mdb.WEB.webSiteSettings.updateOne({ key: 'site' }, { $set: update }, { upsert: true });
+    notifyWebRevalidate('site settings updated');
+    req.flash('success', 'Site settings saved.');
+    res.redirect('/website/settings');
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ── Media library ────────────────────────────────────────────────────────────
+
+// Kept in memory: the bytes are re-encoded by sharp and stored in Mongo, so
+// they never touch the container filesystem, which does not survive a redeploy.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: webMediaService.fileFilter,
+  // Generous, because this is the *source* file. What gets stored is whatever
+  // processImage brings it down to, which is capped at 300KB.
+  limits: { fileSize: 25 * 1024 * 1024 },
+});
+
+export const getMedia = async (req, res, next) => {
+  try {
+    res.render('tailwindcss/website/media', {
+      title: 'Media Library',
+      media: await mediaChoices(),
+      maxBytes: webMediaService.MAX_BYTES,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * Serves an image to the editor itself.
+ *
+ * Separate from the public /api/web/media/:uuid route on purpose: this one is
+ * behind the admin session and shows drafts, so a photograph can be reviewed in
+ * the form before anyone outside the company can see it.
+ */
+export const getMediaFile = async (req, res, next) => {
+  try {
+    const doc = await mdb.WEB.webMedia.findOne({ uuid: req.params.uuid }).select('bytes mime hash').lean();
+    if (!doc || !doc.bytes) return res.status(404).end();
+    res.set('Content-Type', doc.mime);
+    res.set('Cache-Control', 'private, max-age=31536000, immutable');
+    res.set('X-Content-Type-Options', 'nosniff');
+    res.send(Buffer.from(doc.bytes.buffer || doc.bytes));
+  } catch (err) {
+    next(err);
+  }
+};
+
+// csrfService.validate runs AFTER multer: the global CSRF middleware cannot see
+// a multipart body, so the token is only readable once multer has parsed it.
+export const postMediaUpload = [
+  upload.single('image'),
+  csrfService.validate,
+  async (req, res, next) => {
+    try {
+      if (!req.file) {
+        req.flash('error', 'Choose an image to upload.');
+        return res.redirect('/website/media');
+      }
+      const processed = await webMediaService.processImage(req.file.buffer, req.file.originalname);
+
+      // Same bytes as something already here — reuse it rather than storing a
+      // second copy for the mirror to fetch again.
+      const existing = await mdb.WEB.webMedia.findOne({ hash: processed.hash }).select('uuid filename').lean();
+      if (existing) {
+        req.flash('success', `That image is already in the library as "${existing.filename}".`);
+        return res.redirect('/website/media');
+      }
+
+      await mdb.WEB.webMedia.create({
+        filename: processed.filename,
+        originalName: req.file.originalname,
+        mime: processed.mime,
+        bytes: processed.bytes,
+        size: processed.size,
+        width: processed.width,
+        height: processed.height,
+        hash: processed.hash,
+        alt: String(req.body.alt || '').trim(),
+        // Images are published immediately: an unpublished image referenced by
+        // a published page renders as a hole on the live site, and the media
+        // library is not itself a public listing.
+        status: 'published',
+        publishedAt: new Date(),
+        createdBy: req.user?._id,
+        updatedBy: req.user?._id,
+      });
+
+      logger.info('[website] media uploaded', {
+        filename: processed.filename,
+        from: `${req.file.size}b`,
+        to: `${processed.size}b`,
+      });
+      notifyWebRevalidate('media uploaded');
+      req.flash('success', `Uploaded "${processed.filename}" (${Math.round(processed.size / 1024)}KB).`);
+      res.redirect('/website/media');
+    } catch (err) {
+      next(err);
+    }
+  },
+];
+
+export const postMediaDelete = async (req, res, next) => {
+  try {
+    await mdb.WEB.webMedia.deleteOne({ uuid: req.params.uuid });
+    notifyWebRevalidate('media deleted');
+    req.flash('success', 'Image deleted.');
+    res.redirect('/website/media');
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default {
+  getList, getCreate, postCreate, getEdit, postEdit,
+  postPublish, postUnpublish, postDelete,
+  getSettings, postSettings,
+  getMedia, getMediaFile, postMediaUpload, postMediaDelete,
+};

--- a/mongoose/models/mongoose/WEB/accreditation.js
+++ b/mongoose/models/mongoose/WEB/accreditation.js
@@ -1,0 +1,25 @@
+/**
+ * An accreditation logo and its registration details. Mirrors hcs-web's
+ * services/accreditationsData.js.
+ *
+ * membershipNumber and the validity dates are the fields procurement teams
+ * actually ask for, and every one of them is currently [TO SUPPLY] on the live
+ * site. They are optional here so a record can be created before the number is
+ * found, rather than blocking the whole entry on it.
+ */
+import mongoose from 'mongoose';
+import { publishableFields, imageRef } from '../../webContentFields.js';
+
+const accreditationSchema = new mongoose.Schema({
+  ...publishableFields(),
+  slug: { type: String, required: true, unique: true, trim: true, lowercase: true },
+  name: { type: String, required: true, trim: true },
+  logo: { ...imageRef() },
+  description: { type: String, trim: true, default: '' },
+  membershipNumber: { type: String, trim: true, default: '' },
+  validFrom: { type: Date, default: null },
+  validTo: { type: Date, default: null },
+  certificateUrl: { type: String, trim: true, default: '' },
+}, { timestamps: true });
+
+export default { modelName: 'webAccreditation', schema: accreditationSchema };

--- a/mongoose/models/mongoose/WEB/caseStudy.js
+++ b/mongoose/models/mongoose/WEB/caseStudy.js
@@ -1,0 +1,46 @@
+/**
+ * A project story on heroncs.co.uk/studies.
+ *
+ * Field names mirror hcs-web's services/caseStudyData.js exactly, so the site's
+ * service, controller and views need no change when the source swaps from that
+ * file to this collection.
+ *
+ * The brief's format is header (location + scope) → before photo + problem →
+ * after photo + result → optional social-value note. `client` is intentionally
+ * optional and empty by default: naming a housing association on a public site
+ * needs their permission, and a blank is correct until it is given.
+ */
+import mongoose from 'mongoose';
+import { publishableFields, imageRef } from '../../webContentFields.js';
+
+const galleryItemSchema = new mongoose.Schema({
+  ...imageRef(),
+  caption: { type: String, trim: true, default: '' },
+}, { _id: false });
+
+const panelSchema = new mongoose.Schema({
+  ...imageRef(),
+  caption: { type: String, trim: true, default: '' },
+}, { _id: false });
+
+const caseStudySchema = new mongoose.Schema({
+  ...publishableFields(),
+  slug: { type: String, required: true, unique: true, trim: true, lowercase: true },
+  title: { type: String, required: true, trim: true },
+  client: { type: String, trim: true, default: '' },
+  location: { type: String, trim: true, default: '' },
+  scope: { type: String, trim: true, default: '' },
+  excerpt: { type: String, trim: true, default: '' },
+  // Thumbnail for the /studies index. Null renders a text panel rather than an
+  // unrelated photo — see the Jobs Plus entry, which has no usable image yet.
+  card: { ...imageRef() },
+  before: { type: panelSchema, default: () => ({}) },
+  after: { type: panelSchema, default: () => ({}) },
+  gallery: { type: [galleryItemSchema], default: [] },
+  // Rich text (Quill). Named contentHtml because securityService's
+  // RICH_TEXT_FIELDS already whitelists that key for the XSS sanitiser.
+  contentHtml: { type: String, default: '' },
+  socialValue: { type: String, trim: true, default: '' },
+}, { timestamps: true });
+
+export default { modelName: 'webCaseStudy', schema: caseStudySchema };

--- a/mongoose/models/mongoose/WEB/media.js
+++ b/mongoose/models/mongoose/WEB/media.js
@@ -1,0 +1,38 @@
+/**
+ * An image used on heroncs.co.uk. The bytes live in this document.
+ *
+ * Storing them in Mongo rather than on the storage volume is deliberate: the
+ * volume at ~/docker/app/storage is in none of the five nightly backup jobs,
+ * while Mongo is dumped at 02:00 — so bytes here are backed up, survive a
+ * `docker compose pull` redeploy, and need no sixth cron job. Web images are
+ * capped well under Mongo's 16MB document limit by the resize on upload.
+ *
+ * The audit plugin's sanitize() already renders Buffers as "[Buffer N bytes]",
+ * so attaching the trail to this namespace does not copy every image into the
+ * audit log.
+ *
+ * SVG is rejected on upload. These files are served to a third-party origin
+ * (heroncs.co.uk mirrors them), and an SVG is a script-bearing document.
+ */
+import mongoose from 'mongoose';
+import { publishableFields } from '../../webContentFields.js';
+
+const mediaSchema = new mongoose.Schema({
+  ...publishableFields(),
+  // Normalised on upload: lowercased, spaces to hyphens. The originals on the
+  // live site contain spaces, which is what makes them awkward to reference.
+  filename: { type: String, required: true, trim: true },
+  originalName: { type: String, trim: true, default: '' },
+  mime: { type: String, required: true, trim: true },
+  bytes: { type: Buffer, required: true },
+  size: { type: Number, default: 0 },
+  width: { type: Number, default: 0 },
+  height: { type: Number, default: 0 },
+  // Default alt, used when a usage does not supply its own. A usage-specific
+  // alt on the referencing record always wins — see imageRef().
+  alt: { type: String, trim: true, default: '' },
+  // Content hash, served as the ETag and used to dedupe re-uploads.
+  hash: { type: String, trim: true, default: '', index: true },
+}, { timestamps: true });
+
+export default { modelName: 'webMedia', schema: mediaSchema };

--- a/mongoose/models/mongoose/WEB/post.js
+++ b/mongoose/models/mongoose/WEB/post.js
@@ -1,0 +1,21 @@
+/**
+ * A blog post on heroncs.co.uk/blog. Mirrors hcs-web's services/blogData.js.
+ *
+ * `author` is free text rather than a ref to the user who wrote it: the byline
+ * on the public site is usually "HCS Team", not the individual who typed it.
+ * The individual is recorded in updatedBy and in the audit trail.
+ */
+import mongoose from 'mongoose';
+import { publishableFields } from '../../webContentFields.js';
+
+const postSchema = new mongoose.Schema({
+  ...publishableFields(),
+  slug: { type: String, required: true, unique: true, trim: true, lowercase: true },
+  title: { type: String, required: true, trim: true },
+  excerpt: { type: String, trim: true, default: '' },
+  contentHtml: { type: String, default: '' },
+  author: { type: String, trim: true, default: 'HCS Team' },
+  tags: { type: [String], default: [] },
+}, { timestamps: true });
+
+export default { modelName: 'webPost', schema: postSchema };

--- a/mongoose/models/mongoose/WEB/service.js
+++ b/mongoose/models/mongoose/WEB/service.js
@@ -1,0 +1,26 @@
+/**
+ * A service card on heroncs.co.uk/services. Mirrors hcs-web's servicesData.js.
+ *
+ * `href` carries the site's own convention: anything other than /contact means
+ * the service has a dedicated page, which is also what promotes it from an
+ * enquire-only text card to a linked card in the footer (getFooterServices).
+ * Keep that meaning — the footer is generated from it.
+ */
+import mongoose from 'mongoose';
+import { publishableFields, imageRef } from '../../webContentFields.js';
+
+const serviceSchema = new mongoose.Schema({
+  ...publishableFields(),
+  slug: { type: String, required: true, unique: true, trim: true, lowercase: true },
+  title: { type: String, required: true, trim: true },
+  description: { type: String, trim: true, default: '' },
+  image: { ...imageRef() },
+  href: { type: String, trim: true, default: '/contact' },
+  cta: { type: String, trim: true, default: 'Enquire' },
+  // Page-level SEO for a dedicated service page; falls back to title/description.
+  pageTitle: { type: String, trim: true, default: '' },
+  metaDescription: { type: String, trim: true, default: '' },
+  contentHtml: { type: String, default: '' },
+}, { timestamps: true });
+
+export default { modelName: 'webService', schema: serviceSchema };

--- a/mongoose/models/mongoose/WEB/siteSettings.js
+++ b/mongoose/models/mongoose/WEB/siteSettings.js
@@ -1,0 +1,76 @@
+/**
+ * Site identity, contact details, SEO defaults and statutory disclosure —
+ * hcs-web's services/siteData.js.
+ *
+ * A singleton: exactly one document, found by `key: 'site'`. It is modelled as
+ * a collection rather than a config file so it carries the same audit trail and
+ * the same draft/publish gate as everything else in this namespace — the footer
+ * and every page's <head> render from it, so a bad edit is site-wide.
+ *
+ * Offices are an ordered array, not three named keys as on the live site
+ * (liverpool/cheshire/garston). getOffices() there already flattens them into a
+ * list for the footer grid, and the array is what lets one be added or removed
+ * without a code change. Note the brief flags the Cheshire address as possible
+ * dummy data — [TO SUPPLY] confirmation, which is now an edit rather than a PR.
+ */
+import mongoose from 'mongoose';
+import { publishableFields } from '../../webContentFields.js';
+
+const addressSchema = new mongoose.Schema({
+  line1: { type: String, trim: true, default: '' },
+  line2: { type: String, trim: true, default: '' },
+  line3: { type: String, trim: true, default: '' },
+  line4: { type: String, trim: true, default: '' },
+  postcode: { type: String, trim: true, default: '' },
+}, { _id: false });
+
+const officeSchema = new mongoose.Schema({
+  label: { type: String, trim: true, default: '' },
+  phone: { type: String, trim: true, default: '' },
+  address: { type: addressSchema, default: () => ({}) },
+}, { _id: false });
+
+const hoursSchema = new mongoose.Schema({
+  days: { type: String, trim: true, default: '' },
+  time: { type: String, trim: true, default: '' },
+}, { _id: false });
+
+const siteSettingsSchema = new mongoose.Schema({
+  ...publishableFields(),
+  key: { type: String, default: 'site', unique: true, immutable: true },
+
+  name: { type: String, trim: true, default: '' },
+  email: { type: String, trim: true, default: '' },
+  tagline: { type: String, trim: true, default: '' },
+
+  // Statutory disclosure. companyNumber is required on the site by law;
+  // vatNumber is empty until confirmed VAT-registered.
+  companyNumber: { type: String, trim: true, default: '' },
+  registrationCountry: { type: String, trim: true, default: '' },
+  companyType: { type: String, trim: true, default: '' },
+  vatNumber: { type: String, trim: true, default: '' },
+
+  // SEO / social. ogImage is a webMedia uuid; head.ejs skips the social-share
+  // tag entirely when it is empty rather than linking a 404.
+  robots: { type: String, trim: true, default: 'index, follow' },
+  ogType: { type: String, trim: true, default: 'website' },
+  ogImage: { type: String, trim: true, default: '' },
+  twitterCard: { type: String, trim: true, default: 'summary_large_image' },
+  themeColor: { type: String, trim: true, default: '#ffffff' },
+  locale: { type: String, trim: true, default: 'en_GB' },
+
+  // Social handles. Empty means the footer hides that link rather than
+  // rendering one that goes nowhere.
+  twitterHandle: { type: String, trim: true, default: '' },
+  instagramHandle: { type: String, trim: true, default: '' },
+  facebookHandle: { type: String, trim: true, default: '' },
+  linkedinHandle: { type: String, trim: true, default: '' },
+
+  inboxMonitored: { type: String, trim: true, default: '' },
+  inboxResponse: { type: String, trim: true, default: '' },
+
+  hours: { type: [hoursSchema], default: [] },
+  offices: { type: [officeSchema], default: [] },
+}, { timestamps: true });
+
+export default { modelName: 'webSiteSettings', schema: siteSettingsSchema };

--- a/mongoose/models/webContentFields.js
+++ b/mongoose/models/webContentFields.js
@@ -1,0 +1,44 @@
+/**
+ * Shared field definitions for the WEB namespace — the content hcs-web renders.
+ *
+ * Deliberately NOT inside models/mongoose/WEB/: that directory is scanned file
+ * by file by createNamespace() in mongooseDatabaseService.js, and anything there
+ * that does not export { modelName, schema } is logged as a skipped model.
+ *
+ * Every WEB model carries the publication fields below. `status` is the whole
+ * safety mechanism of this module: the public API in webApiController.js
+ * filters on `status: 'published'`, so a record being visible on heroncs.co.uk
+ * is a property of the record, never of the route that happened to read it.
+ */
+import crypto from 'crypto';
+import mongoose from 'mongoose';
+
+export const STATUSES = ['draft', 'published'];
+
+/** uuid + draft/publish + ordering + authorship, spread into every WEB schema. */
+export function publishableFields() {
+  return {
+    uuid: { type: String, unique: true, required: true, default: () => crypto.randomUUID() },
+    status: { type: String, enum: STATUSES, default: 'draft', index: true },
+    // Stamped by the controller on the draft → published transition, and left
+    // alone afterwards: it is the date the site shows, not a modification time.
+    publishedAt: { type: Date, default: null },
+    // Ascending. Ties fall back to the model's own natural order.
+    sortOrder: { type: Number, default: 0 },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'user' },
+    updatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'user' },
+  };
+}
+
+/**
+ * A reference to an uploaded image. Stored as the media record's uuid plus its
+ * alt text, because alt is a property of *this usage* of the image, not of the
+ * file: the same photo is "damaged fencing before works" on one page and
+ * "boundary fencing" on another. The brief requires real alt text everywhere.
+ */
+export function imageRef() {
+  return {
+    media: { type: String, default: '' },   // webMedia.uuid, '' = no image
+    alt: { type: String, trim: true, default: '' },
+  };
+}

--- a/mongoose/routes/webApiRoutes.js
+++ b/mongoose/routes/webApiRoutes.js
@@ -1,0 +1,38 @@
+/**
+ * Public content API consumed by hcs-web.
+ *
+ * Two guards, and neither is the app's usual session check:
+ *
+ * - `webApiLimiter` — these routes are reachable from the internet through the
+ *   frp tunnel at app.heroncs.co.uk, on a domestic connection.
+ * - `requireWebApiToken` — a bearer token, checked in the controller.
+ *
+ * The paths sit under /api/web/ for two concrete reasons. maintenanceService's
+ * wantsJson() already treats /api/ as an API client, so a database outage
+ * answers a JSON 503 rather than an HTML page a consumer cannot parse. And
+ * requestBlocklistService 403s (and counts toward a one-hour autoban) any path
+ * carrying `db`, `backup`, `database` or a .zip/.gz/.sql suffix — worth
+ * remembering before renaming anything here.
+ *
+ * GET only. See webApiController's header for why there is no write surface.
+ */
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import ctrl from '../controllers/webApiController.js';
+
+const router = express.Router();
+
+// Generous enough for a poll every minute from several Passenger workers, plus
+// a burst of media fetches the first time a new photo is published.
+const webApiLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: JSON.stringify({ error: 'Too many requests, try again later.' }),
+});
+
+router.get('/api/web/content', webApiLimiter, ctrl.requireWebApiToken, ctrl.getContent);
+router.get('/api/web/media/:uuid', webApiLimiter, ctrl.requireWebApiToken, ctrl.getMedia);
+
+export default router;

--- a/mongoose/routes/webRoutes.js
+++ b/mongoose/routes/webRoutes.js
@@ -1,0 +1,46 @@
+/**
+ * The website content editor. Admin only, twice over:
+ *
+ * - `routeAccess['/website']` in rolePermissionsConfig — matched by literal
+ *   longest prefix, so this one entry covers every path below.
+ * - `ensureRole('admin')` on each route, the same belt-and-braces as
+ *   company-docs.
+ *
+ * The `:type` parameter is not free-form: webController resolves it through
+ * webContentConfig and 404s on anything it does not name, so the generic routes
+ * cannot be pointed at an arbitrary model.
+ *
+ * `/website/settings` is registered **before** the generic `/website/:type`
+ * routes. Express matches in declaration order, and the singleton needs its own
+ * handlers (no list, no create, no delete).
+ */
+import express from 'express';
+import authService from '../../services/authService.js';
+import ctrl from '../controllers/webController.js';
+
+const router = express.Router();
+const adminOnly = authService.ensureRole('admin');
+
+// ── Site settings (singleton) ───────────────────────────────────────────────
+router.get('/website/settings', adminOnly, ctrl.getSettings);
+router.post('/website/settings', adminOnly, ctrl.postSettings);
+
+// ── Media library ───────────────────────────────────────────────────────────
+router.get('/website/media', adminOnly, ctrl.getMedia);
+router.get('/website/media/:uuid/file', adminOnly, ctrl.getMediaFile);
+// multer first, then csrfService.validate — the global CSRF middleware runs
+// before a multipart body is parsed and would reject every upload.
+router.post('/website/media', adminOnly, ...ctrl.postMediaUpload);
+router.post('/website/media/:uuid/delete', adminOnly, ctrl.postMediaDelete);
+
+// ── Collection types ────────────────────────────────────────────────────────
+router.get('/website/:type', adminOnly, ctrl.getList);
+router.get('/website/:type/create', adminOnly, ctrl.getCreate);
+router.post('/website/:type', adminOnly, ctrl.postCreate);
+router.get('/website/:type/:uuid/edit', adminOnly, ctrl.getEdit);
+router.post('/website/:type/:uuid', adminOnly, ctrl.postEdit);
+router.post('/website/:type/:uuid/publish', adminOnly, ctrl.postPublish);
+router.post('/website/:type/:uuid/unpublish', adminOnly, ctrl.postUnpublish);
+router.post('/website/:type/:uuid/delete', adminOnly, ctrl.postDelete);
+
+export default router;

--- a/mongoose/services/configValidatorService.js
+++ b/mongoose/services/configValidatorService.js
@@ -114,6 +114,11 @@ function validate({ listConfig = {}, crudConfig = {}, modelNames = [] }) {
  */
 function validateAtStartup(mdb) {
   try {
+    // WEB is deliberately absent. Its models are edited only through /website,
+    // which owns the draft/publish gate; they are not registered with the
+    // generic CRUD/list controllers (those iterate REST and INTERNAL), so there
+    // is no config for them to validate. Adding WEB here would only produce
+    // warnings about configs that should not exist.
     const modelNames = ['INTERNAL', 'REST', 'PAPERLESS']
       .flatMap((ns) => Object.keys((mdb && mdb[ns]) || {}));
     const warnings = validate({ listConfig, crudConfig, modelNames });

--- a/mongoose/services/mongooseDatabaseService.js
+++ b/mongoose/services/mongooseDatabaseService.js
@@ -17,7 +17,7 @@ const __dirname = _esmDirname(__filename);
 const AUDIT_EXCLUDE_MODELS = (process.env.AUDIT_EXCLUDE_MODELS || 'auditLog,session')
   .split(',').map((s) => s.trim()).filter(Boolean);
 
-const mdb = { REST: {}, INTERNAL: {}, PAPERLESS: {} };
+const mdb = { REST: {}, INTERNAL: {}, PAPERLESS: {}, WEB: {} };
 let isConnected = false;
 let sshServer = null;
 
@@ -80,9 +80,11 @@ async function createNamespace(ns, connection) {
       logger.warn(`Skipping model in ${ns}: ${file} (missing modelName/schema)`);
       continue;
     }
-    // Attach the audit trail to INTERNAL models, skipping the audit log itself
-    // and high-frequency infrastructure collections (e.g. session writes).
-    if (ns === 'INTERNAL' && !AUDIT_EXCLUDE_MODELS.includes(modelName)) {
+    // Attach the audit trail to INTERNAL and WEB models, skipping the audit log
+    // itself and high-frequency infrastructure collections (e.g. session writes).
+    // WEB is included deliberately: it holds the published website copy, and
+    // "who changed this and when" is the whole point of an editorial trail.
+    if ((ns === 'INTERNAL' || ns === 'WEB') && !AUDIT_EXCLUDE_MODELS.includes(modelName)) {
       schema.plugin(auditPlugin, { modelName });
     }
     connection.model(modelName, schema);
@@ -94,7 +96,7 @@ async function createNamespace(ns, connection) {
 
 mdb.connect = async () => {
   try {
-    if (isConnected && mdb.REST.connection && mdb.INTERNAL.connection && mdb.PAPERLESS.connection) {
+    if (isConnected && mdb.REST.connection && mdb.INTERNAL.connection && mdb.PAPERLESS.connection && mdb.WEB.connection) {
       return mdb;
     }
     let localPort = null;
@@ -151,8 +153,11 @@ mdb.connect = async () => {
     const restDb = configService.get('MONGO_DBNAME_REST', configService.get('MONGO_DBNAME', 'rest'));
     const internalDb = configService.get('MONGO_DBNAME_INTERNAL', configService.get('MONGO_DBNAME', 'internal'));
     const paperlessDb = configService.get('MONGO_DBNAME_PAPERLESS', 'paperless');
+    // Website content authored in /website and pulled by hcs-web. Its own
+    // namespace so the public site's copy is never mixed into the business data.
+    const webDb = configService.get('MONGO_DBNAME_WEB', 'hcs-webdb');
 
-    let restUri, internalUri, paperlessUri;
+    let restUri, internalUri, paperlessUri, webUri;
 
     if (isTunnelEnabled) {
       const mongoUser = encodeURIComponent(configService.get('MONGO_USER', ''));
@@ -160,6 +165,7 @@ mdb.connect = async () => {
       restUri = `mongodb://${mongoUser}:${mongoPass}@127.0.0.1:${localPort}/${restDb}?authSource=admin`;
       internalUri = `mongodb://${mongoUser}:${mongoPass}@127.0.0.1:${localPort}/${internalDb}?authSource=admin`;
       paperlessUri = `mongodb://${mongoUser}:${mongoPass}@127.0.0.1:${localPort}/${paperlessDb}?authSource=admin`;
+      webUri = `mongodb://${mongoUser}:${mongoPass}@127.0.0.1:${localPort}/${webDb}?authSource=admin`;
       if (configService.get('DEBUG')) logger.info('[mongooseDatabaseService] Connected to MongoDB via SSH tunnel');
     } else {
       // Prefer explicit MONGO_URI; otherwise build from parts
@@ -168,29 +174,34 @@ mdb.connect = async () => {
       restUri = getUriWithDb(baseUri, restDb);
       internalUri = getUriWithDb(baseUri, internalDb);
       paperlessUri = getUriWithDb(baseUri, paperlessDb);
+      webUri = getUriWithDb(baseUri, webDb);
       if (configService.get('DEBUG')) logger.info('[mongooseDatabaseService] Connecting to MongoDB via ' + (rawUri ? 'MONGO_URI' : 'MONGO_HOST/PORT/USER/PASS'));
     }
 
     const restConn = mongoose.createConnection(restUri);
     const internalConn = mongoose.createConnection(internalUri);
     const paperlessConn = mongoose.createConnection(paperlessUri);
+    const webConn = mongoose.createConnection(webUri);
 
     await Promise.all([
       new Promise((res, rej) => { restConn.once('open', res); restConn.on('error', rej); }),
       new Promise((res, rej) => { internalConn.once('open', res); internalConn.on('error', rej); }),
-      new Promise((res, rej) => { paperlessConn.once('open', res); paperlessConn.on('error', rej); })
+      new Promise((res, rej) => { paperlessConn.once('open', res); paperlessConn.on('error', rej); }),
+      new Promise((res, rej) => { webConn.once('open', res); webConn.on('error', rej); })
     ]);
 
     if (process.env.DEBUG) {
       logger.info('[mongooseDatabaseService] REST connection open');
       logger.info('[mongooseDatabaseService] INTERNAL connection open');
       logger.info('[mongooseDatabaseService] PAPERLESS connection open');
+      logger.info('[mongooseDatabaseService] WEB connection open');
     }
 
     // Load models into each namespace
     await createNamespace('REST', restConn);
     await createNamespace('INTERNAL', internalConn);
     await createNamespace('PAPERLESS', paperlessConn);
+    await createNamespace('WEB', webConn);
 
     isConnected = true;
     return mdb;
@@ -206,6 +217,7 @@ const cleanup = async () => {
     try { await mdb.REST?.connection?.close(); } catch {}
     try { await mdb.INTERNAL?.connection?.close(); } catch {}
     try { await mdb.PAPERLESS?.connection?.close(); } catch {}
+    try { await mdb.WEB?.connection?.close(); } catch {}
 
     if (sshServer && sshServer.close) {
       sshServer.close();

--- a/mongoose/views/tailwindcss/layout.ejs
+++ b/mongoose/views/tailwindcss/layout.ejs
@@ -198,21 +198,28 @@
           </script>
 
           <% if (typeof quillEditor !== 'undefined' && quillEditor) { %>
-          <!-- Quill JS + init (policy editor pages only) -->
+          <!-- Quill JS + init. Used by the policy editor and by /website.
+               Still exactly one instance per page: the ids below are hardcoded
+               and a second editor would write into the first one's input. -->
           <script src="/resources/vendor/quill.js"></script>
           <script nonce="<%= locals.cspNonce %>">
             (function () {
               var quill = new Quill('#quill-editor', {
                 theme: 'snow',
                 modules: { toolbar: '#quill-toolbar' },
-                placeholder: 'Start typing your policy content…',
+                placeholder: 'Start typing…',
               });
 
               // Pre-populate from existing hidden input (edit mode) — content already rendered
               // in the div by EJS, so Quill reads the DOM directly.
 
-              // On submit: copy Quill HTML into the hidden input
-              var form = document.getElementById('policy-form');
+              // On submit: copy Quill HTML into the hidden input.
+              // closest('form') rather than a hardcoded id, so any page that
+              // opts in with quillEditor works without registering its form id
+              // here. The #policy-form fallback keeps the original behaviour if
+              // the editor is ever rendered outside a form.
+              var editorEl = document.getElementById('quill-editor');
+              var form = (editorEl && editorEl.closest('form')) || document.getElementById('policy-form');
               if (form) {
                 form.addEventListener('submit', function () {
                   document.getElementById('contentHtml-input').value = quill.root.innerHTML;

--- a/mongoose/views/tailwindcss/website/_field.ejs
+++ b/mongoose/views/tailwindcss/website/_field.ejs
@@ -1,0 +1,184 @@
+<%
+  /**
+   * One field of the website content form, dispatched on field.type.
+   *
+   * Locals: field, value, media (the picker's options).
+   *
+   * Repeating groups (gallery, hours, offices) render the rows that exist plus
+   * two blank ones, and the controller drops any row left empty. That is
+   * deliberate rather than a limitation: the CSP forbids inline scripts, so an
+   * "add row" button would need JS in a vendored file to earn its place, and
+   * two spare rows covers how these are actually edited. Saving twice adds four.
+   */
+  const INPUT = 'w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 '
+    + 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white '
+    + 'focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent';
+  const LABEL = 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+  const HELP = 'mt-1 text-xs text-gray-500 dark:text-gray-400';
+  const SUBLABEL = 'block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1';
+
+  const v = value === undefined || value === null ? '' : value;
+  const dateValue = (d) => (d ? new Date(d).toISOString().slice(0, 10) : '');
+  const blankRows = 2;
+%>
+
+<% if (field.type === 'richtext') { %>
+  <%# The Quill toolbar/editor/hidden-input trio. layout.ejs binds these by id,
+      so there can only ever be one on the page — see webContentConfig. %>
+  <label class="<%= LABEL %>"><%= field.label %></label>
+  <div id="quill-toolbar" class="rounded-t-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800">
+    <span class="ql-formats">
+      <select class="ql-header">
+        <option selected></option>
+        <option value="1"></option>
+        <option value="2"></option>
+        <option value="3"></option>
+      </select>
+    </span>
+    <span class="ql-formats">
+      <button class="ql-bold"></button>
+      <button class="ql-italic"></button>
+      <button class="ql-underline"></button>
+    </span>
+    <span class="ql-formats">
+      <button class="ql-list" value="ordered"></button>
+      <button class="ql-list" value="bullet"></button>
+    </span>
+    <span class="ql-formats">
+      <button class="ql-blockquote"></button>
+      <button class="ql-link"></button>
+    </span>
+    <span class="ql-formats">
+      <button class="ql-clean"></button>
+    </span>
+  </div>
+  <div id="quill-editor"
+    class="min-h-64 rounded-b-lg border border-t-0 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm"
+    style="min-height:260px"><%- v %></div>
+  <input type="hidden" name="<%= field.name %>" id="contentHtml-input">
+
+<% } else if (field.type === 'textarea') { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>"><%= field.label %></label>
+  <textarea id="f-<%= field.name %>" name="<%= field.name %>" rows="3" class="<%= INPUT %>"><%= v %></textarea>
+
+<% } else if (field.type === 'number') { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>"><%= field.label %></label>
+  <input id="f-<%= field.name %>" type="number" name="<%= field.name %>" value="<%= v === '' ? 0 : v %>" class="<%= INPUT %>">
+
+<% } else if (field.type === 'date') { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>"><%= field.label %></label>
+  <input id="f-<%= field.name %>" type="date" name="<%= field.name %>" value="<%= dateValue(v) %>" class="<%= INPUT %>">
+
+<% } else if (field.type === 'url') { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>"><%= field.label %></label>
+  <input id="f-<%= field.name %>" type="url" name="<%= field.name %>" value="<%= v %>" class="<%= INPUT %>">
+
+<% } else if (field.type === 'tags') { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>"><%= field.label %></label>
+  <input id="f-<%= field.name %>" type="text" name="<%= field.name %>"
+    value="<%= Array.isArray(v) ? v.join(', ') : v %>" class="<%= INPUT %>">
+
+<% } else if (field.type === 'image' || field.type === 'panel') { %>
+  <%
+    const img = v && typeof v === 'object' ? v : {};
+    const isPanel = field.type === 'panel';
+  %>
+  <label class="<%= LABEL %>"><%= field.label %></label>
+  <div class="rounded-xl border border-gray-200 dark:border-gray-700 p-3 space-y-3">
+    <div class="flex gap-3 items-start">
+      <% if (img.media) { %>
+        <img src="/website/media/<%= img.media %>/file" alt=""
+          class="w-24 h-24 object-cover rounded-lg border border-gray-200 dark:border-gray-700">
+      <% } else { %>
+        <div class="w-24 h-24 rounded-lg border border-dashed border-gray-300 dark:border-gray-600
+                    flex items-center justify-center text-gray-400">
+          <i class="bi bi-image"></i>
+        </div>
+      <% } %>
+      <div class="flex-1 space-y-2">
+        <select name="<%= field.name %>[media]" class="<%= INPUT %>">
+          <option value="">— No image —</option>
+          <% media.forEach(function (m) { %>
+            <option value="<%= m.uuid %>" <%= img.media === m.uuid ? 'selected' : '' %>>
+              <%= m.filename %> (<%= m.width %>×<%= m.height %>)
+            </option>
+          <% }); %>
+        </select>
+        <div>
+          <label class="<%= SUBLABEL %>" for="f-<%= field.name %>-alt">Alt text — describe what is in the photo</label>
+          <input id="f-<%= field.name %>-alt" type="text" name="<%= field.name %>[alt]" value="<%= img.alt || '' %>" class="<%= INPUT %>">
+        </div>
+        <% if (isPanel) { %>
+          <div>
+            <label class="<%= SUBLABEL %>" for="f-<%= field.name %>-caption">Caption</label>
+            <input id="f-<%= field.name %>-caption" type="text" name="<%= field.name %>[caption]" value="<%= img.caption || '' %>" class="<%= INPUT %>">
+          </div>
+        <% } %>
+      </div>
+    </div>
+  </div>
+
+<% } else if (field.type === 'gallery') { %>
+  <% const rows = (Array.isArray(v) ? v : []).concat(Array.from({ length: blankRows }, () => ({}))); %>
+  <label class="<%= LABEL %>"><%= field.label %></label>
+  <div class="space-y-3">
+    <% rows.forEach(function (row, i) { %>
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 p-3 flex gap-3 items-start">
+        <% if (row.media) { %>
+          <img src="/website/media/<%= row.media %>/file" alt=""
+            class="w-16 h-16 object-cover rounded-lg border border-gray-200 dark:border-gray-700">
+        <% } %>
+        <div class="flex-1 grid gap-2 sm:grid-cols-3">
+          <select name="<%= field.name %>[<%= i %>][media]" class="<%= INPUT %>">
+            <option value="">— Empty —</option>
+            <% media.forEach(function (m) { %>
+              <option value="<%= m.uuid %>" <%= row.media === m.uuid ? 'selected' : '' %>><%= m.filename %></option>
+            <% }); %>
+          </select>
+          <input type="text" name="<%= field.name %>[<%= i %>][alt]" value="<%= row.alt || '' %>" placeholder="Alt text" class="<%= INPUT %>">
+          <input type="text" name="<%= field.name %>[<%= i %>][caption]" value="<%= row.caption || '' %>" placeholder="Caption" class="<%= INPUT %>">
+        </div>
+      </div>
+    <% }); %>
+  </div>
+
+<% } else if (field.type === 'hours') { %>
+  <% const rows = (Array.isArray(v) ? v : []).concat(Array.from({ length: blankRows }, () => ({}))); %>
+  <label class="<%= LABEL %>"><%= field.label %></label>
+  <div class="space-y-2">
+    <% rows.forEach(function (row, i) { %>
+      <div class="grid gap-2 sm:grid-cols-2">
+        <input type="text" name="<%= field.name %>[<%= i %>][days]" value="<%= row.days || '' %>" placeholder="Monday – Friday" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][time]" value="<%= row.time || '' %>" placeholder="8:00am – 5:00pm" class="<%= INPUT %>">
+      </div>
+    <% }); %>
+  </div>
+
+<% } else if (field.type === 'offices') { %>
+  <% const rows = (Array.isArray(v) ? v : []).concat(Array.from({ length: blankRows }, () => ({}))); %>
+  <label class="<%= LABEL %>"><%= field.label %></label>
+  <div class="space-y-3">
+    <% rows.forEach(function (row, i) { const a = row.address || {}; %>
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 p-3 grid gap-2 sm:grid-cols-2">
+        <input type="text" name="<%= field.name %>[<%= i %>][label]" value="<%= row.label || '' %>" placeholder="Liverpool office" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][phone]" value="<%= row.phone || '' %>" placeholder="0151 475 1217" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][address][line1]" value="<%= a.line1 || '' %>" placeholder="Address line 1" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][address][line2]" value="<%= a.line2 || '' %>" placeholder="Address line 2" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][address][line3]" value="<%= a.line3 || '' %>" placeholder="Town / city" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][address][line4]" value="<%= a.line4 || '' %>" placeholder="County" class="<%= INPUT %>">
+        <input type="text" name="<%= field.name %>[<%= i %>][address][postcode]" value="<%= a.postcode || '' %>" placeholder="Postcode" class="<%= INPUT %>">
+      </div>
+    <% }); %>
+  </div>
+
+<% } else { %>
+  <label class="<%= LABEL %>" for="f-<%= field.name %>">
+    <%= field.label %><% if (field.required) { %> <span class="text-red-600">*</span><% } %>
+  </label>
+  <input id="f-<%= field.name %>" type="text" name="<%= field.name %>" value="<%= v %>"
+    <%= field.required ? 'required' : '' %> class="<%= INPUT %>">
+<% } %>
+
+<% if (field.help) { %>
+  <p class="<%= HELP %>"><%= field.help %></p>
+<% } %>

--- a/mongoose/views/tailwindcss/website/form.ejs
+++ b/mongoose/views/tailwindcss/website/form.ejs
@@ -1,0 +1,115 @@
+<%
+  // Create/edit for any type in webContentConfig, including the settings
+  // singleton. `record` is null on create.
+  const isNew = !record;
+  const isSingleton = !!cfg.singleton;
+  const action = isSingleton
+    ? '/website/settings'
+    : (isNew ? `/website/${type}` : `/website/${type}/${record.uuid}`);
+  const published = !!record && record.status === 'published';
+  const publicUrl = cfg.publicPath && record
+    ? `https://heroncs.co.uk${cfg.publicPath.replace(':slug', record.slug || '')}`
+    : null;
+%>
+<div class="max-w-4xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+
+  <div class="flex items-center gap-3 mb-6">
+    <a href="<%= isSingleton ? '/website' : `/website/${type}` %>" class="text-sm text-green-700 dark:text-green-400 hover:underline">
+      ← <%= isSingleton ? 'Website' : cfg.plural %>
+    </a>
+    <span class="text-gray-400">/</span>
+    <h1 class="text-xl font-bold"><%= isNew ? `New ${cfg.label}` : title %></h1>
+    <% if (!isNew && !isSingleton) { %>
+      <% if (published) { %>
+        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+                     border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20
+                     text-green-700 dark:text-green-400">
+          <i class="bi bi-globe"></i> Live
+        </span>
+      <% } else { %>
+        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+                     border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400">
+          Draft
+        </span>
+      <% } %>
+    <% } %>
+  </div>
+
+  <% if (published && publicUrl) { %>
+    <div class="mb-6 rounded-2xl border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 p-4">
+      <p class="text-sm text-gray-700 dark:text-gray-300">
+        This is live on the public website at
+        <a href="<%= publicUrl %>" class="font-medium text-green-700 dark:text-green-400 hover:underline"><%= publicUrl %></a>.
+        Saving a change here reaches the site within about a minute.
+      </p>
+    </div>
+  <% } %>
+
+  <form method="POST" action="<%= action %>">
+    <%- include('../partials/csrfHidden') %>
+
+    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-4 space-y-5">
+      <% cfg.fields.forEach(function (field) { %>
+        <div>
+          <%- include('_field', { field: field, value: record ? record[field.name] : undefined, media: media }) %>
+        </div>
+      <% }); %>
+    </div>
+
+    <div class="flex items-center justify-end gap-3 pt-5">
+      <% if (!isSingleton) { %>
+        <a href="/website/<%= type %>" class="text-sm text-gray-500 hover:underline">Cancel</a>
+      <% } %>
+      <button type="submit"
+        class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
+        <%= isNew ? `Create ${cfg.label}` : 'Save' %>
+      </button>
+    </div>
+  </form>
+
+  <%# Publishing is its own form, not a field on the one above: putting
+      something in front of the public should be a separate, deliberate act. %>
+  <% if (!isNew && !isSingleton) { %>
+    <div class="mt-8 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-4">
+      <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">Publishing</h2>
+      <div class="flex flex-wrap items-center gap-3">
+        <% if (published) { %>
+          <form method="POST" action="/website/<%= type %>/<%= record.uuid %>/unpublish">
+            <%- include('../partials/csrfHidden') %>
+            <button type="submit"
+              class="text-sm px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600
+                     bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300
+                     hover:bg-gray-50 dark:hover:bg-gray-800 font-medium transition shadow-sm">
+              Unpublish
+            </button>
+          </form>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Removes it from the public site. Nothing is deleted.</p>
+        <% } else { %>
+          <form method="POST" action="/website/<%= type %>/<%= record.uuid %>/publish">
+            <%- include('../partials/csrfHidden') %>
+            <button type="submit"
+              class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
+              Publish
+            </button>
+          </form>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Makes this visible on heroncs.co.uk.</p>
+        <% } %>
+      </div>
+    </div>
+
+    <div class="mt-6 bg-white dark:bg-gray-900 border border-red-300 dark:border-red-700 rounded-2xl shadow-sm p-4">
+      <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">Delete</h2>
+      <div class="flex flex-wrap items-center gap-3">
+        <form method="POST" action="/website/<%= type %>/<%= record.uuid %>/delete">
+          <%- include('../partials/csrfHidden') %>
+          <button type="submit"
+            class="text-sm bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg shadow-sm font-medium transition">
+            Delete <%= cfg.label %>
+          </button>
+        </form>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Permanent. Unpublish instead if you only want it off the site.</p>
+      </div>
+    </div>
+  <% } %>
+
+</div>

--- a/mongoose/views/tailwindcss/website/list.ejs
+++ b/mongoose/views/tailwindcss/website/list.ejs
@@ -1,0 +1,89 @@
+<%
+  // Generic list for any collection type in webContentConfig.
+  // `cfg.listColumns` names the columns; `status` is rendered as a badge and
+  // everything else as text, so a new column is a config change, not a view one.
+  function cellValue(record, key) {
+    const v = record[key];
+    if (v === undefined || v === null || v === '') return '—';
+    if (v instanceof Date) return v.toISOString().slice(0, 10);
+    return String(v);
+  }
+%>
+<div class="max-w-7xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+
+  <div class="flex items-center gap-3 mb-6">
+    <a href="/website" class="text-sm text-green-700 dark:text-green-400 hover:underline">← Website</a>
+    <span class="text-gray-400">/</span>
+    <h1 class="text-xl font-bold"><i class="bi <%= cfg.icon %> mr-1"></i> <%= cfg.plural %></h1>
+    <span class="ml-auto"></span>
+    <a href="/website/<%= type %>/create"
+      class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
+      New <%= cfg.label %>
+    </a>
+  </div>
+
+  <% if (!records.length) { %>
+    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-8 text-center">
+      <p class="text-sm text-gray-700 dark:text-gray-300">
+        Nothing here yet. Anything you create starts as a draft — the public site only ever shows published records.
+      </p>
+    </div>
+  <% } else { %>
+    <div class="overflow-hidden border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm">
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <% cfg.listColumns.forEach(function (col) { %>
+                <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <%= col === 'publishedAt' ? 'Published' : col === 'href' ? 'Links to' : col === 'validTo' ? 'Valid to' : col === 'membershipNumber' ? 'Membership no.' : col %>
+                </th>
+              <% }); %>
+              <th class="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
+            <% records.forEach(function (record) { %>
+              <tr>
+                <% cfg.listColumns.forEach(function (col) { %>
+                  <td class="px-4 py-3 text-gray-700 dark:text-gray-300">
+                    <% if (col === 'status') { %>
+                      <% if (record.status === 'published') { %>
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+                                     border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20
+                                     text-green-700 dark:text-green-400">
+                          <i class="bi bi-globe"></i> Live
+                        </span>
+                      <% } else { %>
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+                                     border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400">
+                          Draft
+                        </span>
+                      <% } %>
+                    <% } else if (col === cfg.listColumns[0]) { %>
+                      <a href="/website/<%= type %>/<%= record.uuid %>/edit"
+                        class="font-medium text-green-700 dark:text-green-400 hover:underline">
+                        <%= cellValue(record, col) %>
+                      </a>
+                    <% } else { %>
+                      <%= cellValue(record, col) %>
+                    <% } %>
+                  </td>
+                <% }); %>
+                <td class="px-4 py-3 text-right">
+                  <a href="/website/<%= type %>/<%= record.uuid %>/edit"
+                    class="text-xs px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600
+                           bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300
+                           hover:bg-gray-50 dark:hover:bg-gray-800 font-medium transition shadow-sm">
+                    Edit
+                  </a>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% } %>
+
+</div>

--- a/mongoose/views/tailwindcss/website/media.ejs
+++ b/mongoose/views/tailwindcss/website/media.ejs
@@ -1,0 +1,82 @@
+<div class="max-w-7xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+
+  <div class="flex items-center gap-3 mb-6">
+    <a href="/website" class="text-sm text-green-700 dark:text-green-400 hover:underline">← Website</a>
+    <span class="text-gray-400">/</span>
+    <h1 class="text-xl font-bold"><i class="bi bi-images mr-1"></i> Media Library</h1>
+  </div>
+
+  <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-4 mb-8">
+    <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">Upload a photograph</h2>
+
+    <%# enctype is what makes this multipart; the route runs multer before
+        csrfService.validate for exactly that reason. %>
+    <form method="POST" action="/website/media" enctype="multipart/form-data" class="space-y-3">
+      <%- include('../partials/csrfHidden') %>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" for="image">Image file</label>
+          <input id="image" type="file" name="image" accept="image/jpeg,image/png,image/webp,image/avif" required
+            class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+                   bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+                   focus:outline-none focus:ring-2 focus:ring-green-500">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" for="alt">Default alt text</label>
+          <input id="alt" type="text" name="alt" placeholder="New close-board fencing along a boundary"
+            class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+                   bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+                   focus:outline-none focus:ring-2 focus:ring-green-500">
+        </div>
+      </div>
+
+      <p class="text-xs text-gray-500 dark:text-gray-400">
+        Upload the photograph straight off the camera or phone — it is resized, converted to WebP and brought under
+        <%= Math.round(maxBytes / 1024) %>KB automatically. Location data is stripped, which matters on photographs
+        taken on customers' estates. JPEG, PNG, WebP and AVIF only.
+      </p>
+
+      <div class="flex justify-end">
+        <button type="submit"
+          class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
+          Upload
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <% if (!media.length) { %>
+    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-8 text-center">
+      <p class="text-sm text-gray-700 dark:text-gray-300">No images yet.</p>
+    </div>
+  <% } else { %>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <% media.forEach(function (m) { %>
+        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+          <img src="/website/media/<%= m.uuid %>/file" alt="<%= m.alt %>"
+            class="w-full h-40 object-cover border-b border-gray-200 dark:border-gray-700">
+          <div class="p-3 space-y-2">
+            <p class="font-mono text-xs break-all text-gray-700 dark:text-gray-300"><%= m.filename %></p>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              <%= m.width %>×<%= m.height %> · <%= Math.round((m.size || 0) / 1024) %>KB
+            </p>
+            <% if (m.alt) { %>
+              <p class="text-xs text-gray-500 dark:text-gray-400"><%= m.alt %></p>
+            <% } else { %>
+              <p class="text-xs text-amber-700 dark:text-amber-400">No alt text</p>
+            <% } %>
+            <form method="POST" action="/website/media/<%= m.uuid %>/delete">
+              <%- include('../partials/csrfHidden') %>
+              <button type="submit"
+                class="text-xs px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white shadow-sm font-medium transition">
+                Delete
+              </button>
+            </form>
+          </div>
+        </div>
+      <% }); %>
+    </div>
+  <% } %>
+
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "promise-limit": "^2.7.0",
         "qrcode": "^1.5.4",
         "sanitize-filename": "^1.6.3",
+        "sharp": "^0.35.3",
         "socket.io": "^4.8.1",
         "tunnel-ssh": "^4.1.6",
         "twilio": "^6.0.0",
@@ -107,6 +108,516 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1307,6 +1818,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/didyoumean": {
@@ -3537,9 +4057,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3606,6 +4127,55 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/shell-quote": {
       "version": "1.9.0",
@@ -4187,7 +4757,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tunnel-ssh": {
       "version": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.26.0",
+  "version": "6.27.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",
@@ -57,6 +57,7 @@
     "promise-limit": "^2.7.0",
     "qrcode": "^1.5.4",
     "sanitize-filename": "^1.6.3",
+    "sharp": "^0.35.3",
     "socket.io": "^4.8.1",
     "tunnel-ssh": "^4.1.6",
     "twilio": "^6.0.0",

--- a/scripts/seed-web-content.js
+++ b/scripts/seed-web-content.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * One-off import of the live website's content into the WEB namespace.
+ *
+ * The editor at /website is useless on an empty database: nobody writes their
+ * first case study by re-typing the one already on the site. This reads the
+ * content out of an hcs-web checkout — its services/*Data.js files and its
+ * public/images — and creates the matching records.
+ *
+ *   node scripts/seed-web-content.js --from ~/code/hcs-web [--publish] [--dry-run]
+ *
+ * Notes on the shape of this:
+ *
+ * - **It takes a path rather than bundling a fixture.** The seed is 7.3MB of
+ *   photographs; copying them into this repo would put them in every image
+ *   build for the sake of a script that runs once.
+ * - **It is idempotent by slug and by image hash.** Re-running adds nothing and
+ *   overwrites nothing, so it is safe to run again after a partial failure.
+ * - **Everything lands as a draft unless --publish is passed.** The images are
+ *   the exception: an unpublished image referenced by a published page renders
+ *   as a hole, and the media library is not itself a public listing.
+ * - hcs-web is CommonJS; this is ESM. createRequire is what bridges them.
+ */
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import mdb from '../mongoose/services/mongooseDatabaseService.js';
+import { slugify } from '../services/webContentService.js';
+import { processImage } from '../services/webMediaService.js';
+
+const args = process.argv.slice(2);
+const arg = (name, fallback = null) => {
+  const i = args.indexOf(name);
+  return i > -1 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : fallback;
+};
+const has = (name) => args.includes(name);
+
+const FROM = arg('--from');
+const PUBLISH = has('--publish');
+const DRY = has('--dry-run');
+
+if (!FROM) {
+  console.error('Usage: node scripts/seed-web-content.js --from /path/to/hcs-web [--publish] [--dry-run]');
+  process.exit(1);
+}
+
+const root = path.resolve(FROM.replace(/^~/, process.env.HOME || '~'));
+const require_ = createRequire(import.meta.url);
+const load = (file) => require_(path.join(root, 'services', file));
+
+const state = { media: 0, studies: 0, posts: 0, services: 0, accreditations: 0, site: 0, skipped: 0 };
+const publishFields = () => (PUBLISH ? { status: 'published', publishedAt: new Date() } : { status: 'draft' });
+
+/**
+ * Imports an image referenced by the site as "/images/fence before.jpeg".
+ * Returns the media uuid, or '' when the file is missing — which is not an
+ * error worth stopping for: the live data files reference a couple of images
+ * that were never added.
+ */
+const mediaByPath = new Map();
+async function importImage(webPath, alt = '') {
+  if (!webPath) return '';
+  if (mediaByPath.has(webPath)) return mediaByPath.get(webPath);
+
+  const file = path.join(root, 'public', webPath.replace(/^\//, '').replace(/\\/g, '/'));
+  if (!fs.existsSync(file)) {
+    console.warn(`  ! missing image, skipped: ${webPath}`);
+    mediaByPath.set(webPath, '');
+    return '';
+  }
+
+  const processed = await processImage(fs.readFileSync(file), path.basename(file));
+  const existing = await mdb.WEB.webMedia.findOne({ hash: processed.hash }).select('uuid').lean();
+  if (existing) {
+    mediaByPath.set(webPath, existing.uuid);
+    return existing.uuid;
+  }
+  if (DRY) {
+    mediaByPath.set(webPath, 'dry-run');
+    console.log(`  + image ${processed.filename} (${Math.round(processed.size / 1024)}KB)`);
+    return 'dry-run';
+  }
+
+  const doc = await mdb.WEB.webMedia.create({
+    filename: processed.filename,
+    originalName: path.basename(file),
+    mime: processed.mime,
+    bytes: processed.bytes,
+    size: processed.size,
+    width: processed.width,
+    height: processed.height,
+    hash: processed.hash,
+    alt,
+    status: 'published',
+    publishedAt: new Date(),
+  });
+  state.media += 1;
+  mediaByPath.set(webPath, doc.uuid);
+  console.log(`  + image ${processed.filename} (${Math.round(processed.size / 1024)}KB)`);
+  return doc.uuid;
+}
+
+const SINGULAR = {
+  studies: 'case study', posts: 'post', services: 'service', accreditations: 'accreditation',
+};
+
+async function createIfNew(Model, slug, doc, counter) {
+  const existing = await Model.findOne({ slug }).select('uuid').lean();
+  if (existing) {
+    state.skipped += 1;
+    return false;
+  }
+  if (!DRY) await Model.create({ ...doc, slug });
+  state[counter] += 1;
+  console.log(`  + ${SINGULAR[counter] || counter}: ${slug}`);
+  return true;
+}
+
+async function main() {
+  console.log(`Seeding the WEB namespace from ${root}${DRY ? ' (dry run)' : ''}`);
+  await mdb.connect();
+
+  // ── Case studies ──────────────────────────────────────────────────────────
+  const { getPosts } = load('blogData.js');
+  const { getServices } = load('servicesData.js');
+  const { getAccreditations } = load('accreditationsData.js');
+  const { getSite, getOffices } = load('siteData.js');
+  const { getStudies } = load('caseStudyData.js');
+  const studies = getStudies();
+
+  for (const s of studies) {
+    const panel = async (p) => (p ? { media: await importImage(p.image, p.alt), alt: p.alt || '', caption: p.caption || '' } : { media: '', alt: '', caption: '' });
+    await createIfNew(mdb.WEB.webCaseStudy, s.slug || slugify(s.title), {
+      title: s.title,
+      client: s.client || '',
+      location: s.location || '',
+      scope: s.scope || '',
+      excerpt: s.excerpt || '',
+      card: { media: await importImage(s.cardImage, s.cardImageAlt), alt: s.cardImageAlt || '' },
+      before: await panel(s.before),
+      after: await panel(s.after),
+      gallery: await Promise.all((s.gallery || []).map(async (g) => ({
+        media: await importImage(g.image, g.alt), alt: g.alt || '', caption: g.caption || '',
+      }))),
+      contentHtml: s.content || '',
+      socialValue: s.socialValue || '',
+      ...publishFields(),
+    }, 'studies');
+  }
+
+  // ── Blog posts ────────────────────────────────────────────────────────────
+  for (const p of getPosts()) {
+    await createIfNew(mdb.WEB.webPost, p.slug || slugify(p.title), {
+      title: p.title,
+      excerpt: p.excerpt || '',
+      contentHtml: p.content || '',
+      author: p.author || 'HCS Team',
+      tags: p.tags || [],
+      ...publishFields(),
+      publishedAt: PUBLISH && p.publishedAt ? new Date(p.publishedAt) : publishFields().publishedAt || null,
+    }, 'posts');
+  }
+
+  // ── Services ──────────────────────────────────────────────────────────────
+  let order = 0;
+  for (const s of getServices()) {
+    order += 10;
+    await createIfNew(mdb.WEB.webService, s.slug || slugify(s.title), {
+      title: s.title,
+      description: s.description || '',
+      image: { media: await importImage(s.image, s.imageAlt), alt: s.imageAlt || '' },
+      href: s.href || '/contact',
+      cta: s.cta || 'Enquire',
+      pageTitle: s.pageTitle || '',
+      metaDescription: s.metaDescription || '',
+      sortOrder: order,
+      ...publishFields(),
+    }, 'services');
+  }
+
+  // ── Accreditations ────────────────────────────────────────────────────────
+  order = 0;
+  for (const a of getAccreditations()) {
+    order += 10;
+    await createIfNew(mdb.WEB.webAccreditation, slugify(a.name), {
+      name: a.name,
+      logo: { media: await importImage(a.logo, a.alt), alt: a.alt || a.name },
+      description: a.description || '',
+      membershipNumber: a.membershipNumber || '',
+      sortOrder: order,
+      ...publishFields(),
+    }, 'accreditations');
+  }
+
+  // ── Site settings ─────────────────────────────────────────────────────────
+  const existingSite = await mdb.WEB.webSiteSettings.findOne({ key: 'site' }).select('uuid').lean();
+  if (existingSite) {
+    state.skipped += 1;
+  } else {
+    const site = getSite();
+    const doc = {
+      key: 'site',
+      name: site.name || '',
+      email: site.email || '',
+      tagline: site.tagline || '',
+      companyNumber: site.companyNumber || '',
+      registrationCountry: site.registrationCountry || '',
+      companyType: site.companyType || '',
+      vatNumber: site.vatNumber || '',
+      robots: site.robots || 'index, follow',
+      ogType: site.ogType || 'website',
+      twitterCard: site.twitterCard || 'summary_large_image',
+      themeColor: site.themeColor || '#ffffff',
+      locale: site.locale || 'en_GB',
+      twitterHandle: site.twitterHandle || '',
+      instagramHandle: site.instagramHandle || '',
+      facebookHandle: site.facebookHandle || '',
+      linkedinHandle: site.linkedinHandle || '',
+      inboxMonitored: site.inbox?.monitored || '',
+      inboxResponse: site.inbox?.response || '',
+      hours: site.hours || [],
+      offices: (getOffices ? getOffices(site) : []).map((o) => ({
+        label: o.label, phone: o.phone, address: o.address,
+      })),
+      ...publishFields(),
+    };
+    if (!DRY) await mdb.WEB.webSiteSettings.create(doc);
+    state.site = 1;
+    console.log('  + site settings');
+  }
+
+  console.log('\nDone.', JSON.stringify(state));
+  if (!PUBLISH) {
+    console.log('Everything imported as a draft. Review it at /website, then publish.');
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/services/authService.js
+++ b/services/authService.js
@@ -39,6 +39,15 @@ const PUBLIC_PREFIXES = [
   "/resources/vendor/",
   "/manifest/",
   "/legal/",
+  // Read-only website content API pulled by hcs-web. It has no browser session
+  // — it authenticates with a bearer token checked in webApiController — so it
+  // must bypass ensureAuthenticated. The prefix rather than exact paths is
+  // needed because /api/web/media/:uuid carries a uuid.
+  //
+  // Note the narrowing lesson above applies here too: this prefix must stay
+  // "/api/web/" and nothing broader. Everything under it is GET-only and
+  // token-guarded; a write route added there would inherit this bypass.
+  "/api/web/",
 ];
 
 // Paths accessible to authenticated-but-unverified users

--- a/services/maintenanceService.js
+++ b/services/maintenanceService.js
@@ -55,6 +55,9 @@ function wantsJson(req) {
 function dbState() {
   // Connections are created on mdb.connect(); absent connections mean the
   // app is still in its startup phase rather than having lost the database.
+  // WEB is excluded on purpose: it carries the public website's content, and
+  // the business app must not 503 because the marketing copy is unreachable.
+  // Its state is still logged below, and mdb.connect() requires it at boot.
   const conns = [mdb.REST, mdb.INTERNAL, mdb.PAPERLESS];
   if (conns.some((c) => !c || !c.connection)) return "starting";
   const allReady = conns.every((c) => c.connection.readyState === 1);
@@ -136,6 +139,7 @@ function maintenanceService(req, res, next) {
           restReady: mdb.REST?.connection?.readyState === 1,
           internalReady: mdb.INTERNAL?.connection?.readyState === 1,
           paperlessReady: mdb.PAPERLESS?.connection?.readyState === 1,
+          webReady: mdb.WEB?.connection?.readyState === 1,
         });
       }
       return renderUnavailable(req, res, state);

--- a/services/webContentService.js
+++ b/services/webContentService.js
@@ -1,0 +1,212 @@
+/**
+ * Builds the content payload that hcs-web pulls and mirrors.
+ *
+ * hcs-web is a *cache* of this data, not a client of it: it writes whatever
+ * this returns to disk and serves the public site from that copy, so
+ * heroncs.co.uk keeps working with hcs-app switched off entirely. Two
+ * consequences shape everything here.
+ *
+ * 1. **The payload is self-contained.** No pagination, no follow-up lookups for
+ *    anything the page needs to render. The one exception is image bytes, which
+ *    are fetched per-uuid and mirrored separately — see media[] below.
+ *
+ * 2. **Only `status: 'published'` is ever included.** That filter lives here,
+ *    once, rather than in each route: a record being visible on the public
+ *    internet is a property of the record, never of the caller that read it.
+ *    tests/webContentService.test.js pins it.
+ *
+ * Field names deliberately match hcs-web's services/*Data.js objects, so its
+ * getters can return these straight through without a translation layer.
+ */
+import crypto from 'crypto';
+import mdb from '../mongoose/services/mongooseDatabaseService.js';
+
+/** Records a consumer may render. Everything else is invisible to the API. */
+const PUBLISHED = { status: 'published' };
+
+/** URL-safe slug. Mirrors the slugs already in hcs-web's data files. */
+export function slugify(input) {
+  return String(input || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')  // strip accents
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+/**
+ * An image reference as the consumer sees it: the media uuid plus the alt text
+ * for *this* usage.
+ *
+ * The uuid rather than a URL is deliberate — hcs-web mirrors the bytes locally
+ * and serves them from its own path, so a URL minted here would either be wrong
+ * or would tie the public site's page loads to this host being reachable, which
+ * is the whole thing this design avoids.
+ */
+function imageOut(ref, fallbackAlt = '') {
+  if (!ref || !ref.media) return null;
+  return { media: ref.media, alt: ref.alt || fallbackAlt };
+}
+
+function studyOut(d) {
+  return {
+    slug: d.slug,
+    title: d.title,
+    client: d.client || '',
+    location: d.location || '',
+    scope: d.scope || '',
+    excerpt: d.excerpt || '',
+    card: imageOut(d.card),
+    before: d.before && d.before.media
+      ? { ...imageOut(d.before), caption: d.before.caption || '' }
+      : null,
+    after: d.after && d.after.media
+      ? { ...imageOut(d.after), caption: d.after.caption || '' }
+      : null,
+    gallery: (d.gallery || [])
+      .filter((g) => g && g.media)
+      .map((g) => ({ ...imageOut(g), caption: g.caption || '' })),
+    content: d.contentHtml || '',
+    socialValue: d.socialValue || null,
+    publishedAt: d.publishedAt || null,
+  };
+}
+
+function postOut(d) {
+  return {
+    slug: d.slug,
+    title: d.title,
+    excerpt: d.excerpt || '',
+    content: d.contentHtml || '',
+    author: d.author || '',
+    // hcs-web renders this as a plain date string; ISO keeps it sortable and
+    // unambiguous, and the consumer formats it.
+    publishedAt: d.publishedAt ? new Date(d.publishedAt).toISOString() : null,
+    tags: d.tags || [],
+  };
+}
+
+function serviceOut(d) {
+  return {
+    slug: d.slug,
+    title: d.title,
+    description: d.description || '',
+    image: imageOut(d.image),
+    // hcs-web's own convention: anything other than /contact means the service
+    // has a dedicated page, which is also what promotes it in the footer.
+    href: d.href || '/contact',
+    cta: d.cta || 'Enquire',
+    pageTitle: d.pageTitle || '',
+    metaDescription: d.metaDescription || '',
+    content: d.contentHtml || '',
+  };
+}
+
+function accreditationOut(d) {
+  return {
+    slug: d.slug,
+    name: d.name,
+    logo: imageOut(d.logo, d.name),
+    description: d.description || '',
+    membershipNumber: d.membershipNumber || '',
+    validFrom: d.validFrom ? new Date(d.validFrom).toISOString() : null,
+    validTo: d.validTo ? new Date(d.validTo).toISOString() : null,
+    certificateUrl: d.certificateUrl || '',
+  };
+}
+
+function siteOut(d) {
+  if (!d) return null;
+  return {
+    name: d.name || '',
+    email: d.email || '',
+    tagline: d.tagline || '',
+    companyNumber: d.companyNumber || '',
+    registrationCountry: d.registrationCountry || '',
+    companyType: d.companyType || '',
+    vatNumber: d.vatNumber || '',
+    robots: d.robots || 'index, follow',
+    ogType: d.ogType || 'website',
+    ogImage: d.ogImage || '',
+    twitterCard: d.twitterCard || 'summary_large_image',
+    themeColor: d.themeColor || '#ffffff',
+    locale: d.locale || 'en_GB',
+    twitterHandle: d.twitterHandle || '',
+    instagramHandle: d.instagramHandle || '',
+    facebookHandle: d.facebookHandle || '',
+    linkedinHandle: d.linkedinHandle || '',
+    inbox: { monitored: d.inboxMonitored || '', response: d.inboxResponse || '' },
+    hours: (d.hours || []).map((h) => ({ days: h.days || '', time: h.time || '' })),
+    offices: (d.offices || []).map((o) => ({
+      label: o.label || '',
+      phone: o.phone || '',
+      address: {
+        line1: o.address?.line1 || '',
+        line2: o.address?.line2 || '',
+        line3: o.address?.line3 || '',
+        line4: o.address?.line4 || '',
+        postcode: o.address?.postcode || '',
+      },
+    })),
+  };
+}
+
+/**
+ * Image *metadata* only — never the bytes.
+ *
+ * The manifest is what lets hcs-web mirror incrementally: it compares each
+ * hash against what it already holds and fetches only the changed ones from
+ * /api/web/media/:uuid. Inlining the bytes here would put every photo on the
+ * wire on every poll, several megabytes at a time, to answer a question that is
+ * almost always "nothing changed".
+ */
+function mediaOut(d) {
+  return {
+    uuid: d.uuid,
+    filename: d.filename,
+    mime: d.mime,
+    size: d.size || 0,
+    width: d.width || 0,
+    height: d.height || 0,
+    hash: d.hash || '',
+    alt: d.alt || '',
+  };
+}
+
+/** Everything published, in one document. */
+export async function buildPayload() {
+  const W = mdb.WEB;
+  const [site, services, accreditations, posts, studies, media] = await Promise.all([
+    W.webSiteSettings.findOne(PUBLISHED).lean(),
+    W.webService.find(PUBLISHED).sort({ sortOrder: 1, title: 1 }).lean(),
+    W.webAccreditation.find(PUBLISHED).sort({ sortOrder: 1, name: 1 }).lean(),
+    W.webPost.find(PUBLISHED).sort({ publishedAt: -1, createdAt: -1 }).lean(),
+    W.webCaseStudy.find(PUBLISHED).sort({ sortOrder: 1, title: 1 }).lean(),
+    W.webMedia.find(PUBLISHED).select('-bytes').sort({ createdAt: 1 }).lean(),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    site: siteOut(site),
+    services: services.map(serviceOut),
+    accreditations: accreditations.map(accreditationOut),
+    posts: posts.map(postOut),
+    studies: studies.map(studyOut),
+    media: media.map(mediaOut),
+  };
+}
+
+/**
+ * Content hash of a payload, used as its ETag.
+ *
+ * generatedAt is excluded, which is the point: it changes on every call, so
+ * hashing it would make every poll a 200 with a full body and the 304 path
+ * would never fire.
+ */
+export function payloadEtag(payload) {
+  const { generatedAt, ...stable } = payload;
+  return `"${crypto.createHash('sha256').update(JSON.stringify(stable)).digest('hex').slice(0, 32)}"`;
+}
+
+export default { slugify, buildPayload, payloadEtag };

--- a/services/webMediaService.js
+++ b/services/webMediaService.js
@@ -1,0 +1,112 @@
+/**
+ * Prepares an uploaded photograph for the public website.
+ *
+ * The Website Design Brief sets a 300KB ceiling per image and forbids stock
+ * photography; the live site currently carries 15 files over that limit, two of
+ * them ~1MB. Rather than trusting whoever uploads to have exported correctly,
+ * every image is re-encoded here.
+ *
+ * Three things this does that are easy to leave out and expensive to add later:
+ *
+ * - **Strips metadata.** sharp drops EXIF unless asked to keep it, which is the
+ *   behaviour we want: site photographs are taken on phones on customers'
+ *   estates, and EXIF carries GPS coordinates. Publishing those would put the
+ *   location of a housing association's property on the internet.
+ * - **Normalises the filename.** The existing images are named "fence complete
+ *   5.jpeg" — spaces and all — which is why referencing them is awkward.
+ * - **Rejects SVG.** These bytes are mirrored and served by heroncs.co.uk, and
+ *   an SVG is a script-bearing document, not an image.
+ */
+import crypto from 'crypto';
+import path from 'path';
+import sharp from 'sharp';
+
+/** Longest edge, in pixels. Comfortably covers a full-width hero on 2x. */
+export const MAX_EDGE = 2000;
+
+/** The brief's ceiling. */
+export const MAX_BYTES = 300 * 1024;
+
+/**
+ * The ladder tried in order until the output fits MAX_BYTES.
+ *
+ * It steps down *quality first, then dimensions*, because dropping resolution
+ * is the more visible loss and should be the later resort. The last entry is
+ * accepted whatever it weighs: a slightly oversized image is a better outcome
+ * than an upload that fails with nothing the person can act on.
+ *
+ * Dimensions matter as well as quality because quality alone does not converge
+ * on a detailed photograph — foliage, gravel and brickwork, which is most of
+ * what this company photographs, compress badly at any quality.
+ */
+const LADDER = [
+  { edge: MAX_EDGE, quality: 82 },
+  { edge: MAX_EDGE, quality: 72 },
+  { edge: MAX_EDGE, quality: 62 },
+  { edge: 1600, quality: 62 },
+  { edge: 1280, quality: 60 },
+  { edge: 1024, quality: 58 },
+  { edge: 800, quality: 55 },
+];
+
+/** Uploads we accept. Deliberately no image/svg+xml — see the header. */
+export const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif']);
+
+/** multer fileFilter: checks the declared mime AND the extension. */
+export function fileFilter(req, file, cb) {
+  const extOk = /\.(jpe?g|png|webp|avif)$/i.test(file.originalname || '');
+  const mimeOk = ALLOWED_MIME.has(String(file.mimetype || '').toLowerCase());
+  if (extOk && mimeOk) return cb(null, true);
+  return cb(new Error('Only JPEG, PNG, WebP or AVIF images are accepted.'));
+}
+
+/** "fence complete 5.jpeg" → "fence-complete-5.webp" */
+export function normaliseFilename(originalName, ext = 'webp') {
+  const base = path.basename(String(originalName || 'image'), path.extname(String(originalName || '')));
+  const clean = base
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'image';
+  return `${clean}.${ext}`;
+}
+
+/**
+ * Re-encode to WebP within the size and dimension limits.
+ *
+ * Returns { bytes, mime, size, width, height, filename, hash }. The hash is of
+ * the *output*, so re-uploading the same source file twice produces the same
+ * hash and hcs-web's mirror skips the re-fetch.
+ */
+export async function processImage(buffer, originalName) {
+  const meta = await sharp(buffer).metadata();
+
+  let out = null;
+  for (const step of LADDER) {
+    // withoutEnlargement: a small logo stays its own size rather than being
+    // upscaled into a blurry 2000px version of itself.
+    out = await sharp(buffer, { failOn: 'error' })
+      .rotate()  // apply EXIF orientation before it is discarded
+      .resize({ width: step.edge, height: step.edge, fit: 'inside', withoutEnlargement: true })
+      .webp({ quality: step.quality })
+      .toBuffer({ resolveWithObject: true });
+    if (out.data.length <= MAX_BYTES) break;
+  }
+
+  return {
+    bytes: out.data,
+    mime: 'image/webp',
+    size: out.data.length,
+    width: out.info.width,
+    height: out.info.height,
+    // Source dimensions are not kept: the stored image is the only one served,
+    // so its own dimensions are the ones a consumer needs.
+    filename: normaliseFilename(originalName),
+    hash: crypto.createHash('sha256').update(out.data).digest('hex'),
+    sourceFormat: meta.format || '',
+  };
+}
+
+export default { processImage, fileFilter, normaliseFilename, MAX_EDGE, MAX_BYTES, ALLOWED_MIME };

--- a/services/webRevalidateService.js
+++ b/services/webRevalidateService.js
@@ -1,0 +1,51 @@
+/**
+ * Tells hcs-web that its mirror is stale.
+ *
+ * This is an optimisation and nothing more. hcs-web polls on a timer and would
+ * pick the change up on its own; the hook just turns "within a few minutes"
+ * into "within a second or two". Everything here follows from that:
+ *
+ * - **It never blocks or fails a save.** Errors are logged and swallowed. An
+ *   editor must not see a save fail because a website on someone else's shared
+ *   host did not answer.
+ * - **It is fire-and-forget.** The caller does not await it.
+ * - **It is not required to be delivered.** heroncs.co.uk runs several
+ *   Passenger worker processes and this reaches exactly one of them; the others
+ *   converge through the shared on-disk mirror on their next tick. Do not
+ *   redesign this into something that assumes it hit them all.
+ *
+ * Unset WEB_REVALIDATE_URL disables it silently — the poll still works, which
+ * is why this is not an error.
+ */
+import logger from './loggerService.js';
+
+const TIMEOUT_MS = 5000;
+
+export function notifyWebRevalidate(reason = 'content changed') {
+  const url = String(process.env.WEB_REVALIDATE_URL || '').trim();
+  const secret = String(process.env.WEB_REVALIDATE_SECRET || '').trim();
+  if (!url || !secret) return;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify({ reason }),
+    signal: controller.signal,
+  })
+    .then((r) => {
+      if (!r.ok) logger.warn('[webRevalidate] hcs-web returned ' + r.status, { reason });
+      else logger.info('[webRevalidate] hcs-web notified', { reason });
+    })
+    .catch((err) => {
+      logger.warn('[webRevalidate] could not reach hcs-web: ' + err.message, { reason });
+    })
+    .finally(() => clearTimeout(timer));
+}
+
+export default { notifyWebRevalidate };

--- a/tests/webContentService.test.js
+++ b/tests/webContentService.test.js
@@ -1,0 +1,193 @@
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import mdb from '../mongoose/services/mongooseDatabaseService.js';
+import webContentConfig from '../mongoose/config/webContentConfig.js';
+import { buildPayload, payloadEtag, slugify } from '../services/webContentService.js';
+
+/**
+ * The payload hcs-web mirrors and serves the public site from.
+ *
+ * The assertion that matters is the first one: the published filter is applied
+ * in the query, once, for every collection. If a draft ever reaches this
+ * payload it reaches heroncs.co.uk, and it stays there in hcs-web's disk cache
+ * even after the mistake is corrected here — the mirror is only refreshed by a
+ * later successful pull.
+ */
+
+// What each mocked collection was queried with, so the filter can be asserted
+// rather than inferred from the rows a stub chose to return.
+let queries = [];
+
+function chain(rows) {
+  return {
+    sort: mock.fn(() => ({ lean: mock.fn(async () => rows) })),
+    select: mock.fn(() => ({ sort: mock.fn(() => ({ lean: mock.fn(async () => rows) })) })),
+    lean: mock.fn(async () => rows),
+  };
+}
+
+function collection(rows) {
+  return {
+    find: mock.fn((q) => { queries.push(q); return chain(rows); }),
+    findOne: mock.fn((q) => { queries.push(q); return chain(rows[0] || null); }),
+  };
+}
+
+function patchWeb({
+  site = null, services = [], accreditations = [], posts = [], studies = [], media = [],
+} = {}) {
+  queries = [];
+  mdb.WEB = {
+    ...mdb.WEB,
+    webSiteSettings: collection(site ? [site] : []),
+    webService: collection(services),
+    webAccreditation: collection(accreditations),
+    webPost: collection(posts),
+    webCaseStudy: collection(studies),
+    webMedia: collection(media),
+  };
+}
+
+describe('webContentService.buildPayload', () => {
+  beforeEach(() => patchWeb());
+
+  it('filters every collection on published, in the query', async () => {
+    await buildPayload();
+    assert.equal(queries.length, 6, 'expected one query per collection');
+    for (const q of queries) {
+      assert.deepEqual(q, { status: 'published' }, 'a collection was read without the published filter');
+    }
+  });
+
+  it('returns an entry for every content type', async () => {
+    const payload = await buildPayload();
+    for (const key of ['site', 'services', 'accreditations', 'posts', 'studies', 'media']) {
+      assert.ok(key in payload, `payload is missing ${key}`);
+    }
+  });
+
+  it('never includes image bytes in the manifest', async () => {
+    // The bytes are fetched per-uuid. Inlining them would put megabytes on the
+    // wire on every poll to answer "nothing changed".
+    patchWeb({ media: [{ uuid: 'm1', filename: 'fence.webp', mime: 'image/webp', size: 1, hash: 'h' }] });
+    const payload = await buildPayload();
+    assert.equal(payload.media.length, 1);
+    assert.ok(!('bytes' in payload.media[0]), 'the manifest carries image bytes');
+  });
+
+  it('renders a case study in the shape hcs-web already expects', async () => {
+    patchWeb({
+      studies: [{
+        slug: 'estate-fencing-replacement',
+        title: 'Estate fencing replacement',
+        client: '',
+        location: 'Merseyside',
+        excerpt: 'Aging boundary fencing replaced.',
+        card: { media: 'm1', alt: 'Completed fencing' },
+        before: { media: 'm2', alt: 'Damaged fencing', caption: 'Due for replacement.' },
+        after: { media: 'm1', alt: 'New fencing', caption: 'Clean, level, usable.' },
+        gallery: [{ media: 'm3', alt: 'Panels going in', caption: '' }],
+        contentHtml: '<p>Full write-up.</p>',
+        socialValue: null,
+      }],
+    });
+    const [study] = (await buildPayload()).studies;
+    assert.equal(study.slug, 'estate-fencing-replacement');
+    assert.equal(study.client, '', 'an unnamed client must stay blank, not become a placeholder');
+    assert.deepEqual(study.card, { media: 'm1', alt: 'Completed fencing' });
+    assert.equal(study.before.caption, 'Due for replacement.');
+    assert.equal(study.gallery.length, 1);
+    // hcs-web's views read `content`, not `contentHtml`.
+    assert.equal(study.content, '<p>Full write-up.</p>');
+  });
+
+  it('drops gallery rows and panels with no image', async () => {
+    // The form renders blank spare rows; they must not reach the site as holes.
+    patchWeb({
+      studies: [{
+        slug: 's', title: 'T',
+        before: { media: '', alt: '', caption: '' },
+        gallery: [{ media: 'm1', alt: 'a' }, { media: '', alt: '' }],
+      }],
+    });
+    const [study] = (await buildPayload()).studies;
+    assert.equal(study.before, null);
+    assert.equal(study.gallery.length, 1);
+  });
+
+  it('returns a null site rather than throwing when settings are unpublished', async () => {
+    // hcs-web falls back to its own seed data on a null; a throw here would
+    // fail the whole pull and freeze the mirror on a stale copy instead.
+    const payload = await buildPayload();
+    assert.equal(payload.site, null);
+  });
+});
+
+describe('webContentService.payloadEtag', () => {
+  it('ignores generatedAt', () => {
+    // Hashing it would make every poll a 200 with a full body, and the 304
+    // path — the entire point of the ETag — would never fire.
+    const a = { generatedAt: '2026-01-01T00:00:00.000Z', posts: [{ slug: 'x' }] };
+    const b = { generatedAt: '2026-08-18T09:30:00.000Z', posts: [{ slug: 'x' }] };
+    assert.equal(payloadEtag(a), payloadEtag(b));
+  });
+
+  it('changes when the content changes', () => {
+    const a = { generatedAt: 'z', posts: [{ slug: 'x' }] };
+    const b = { generatedAt: 'z', posts: [{ slug: 'y' }] };
+    assert.notEqual(payloadEtag(a), payloadEtag(b));
+  });
+
+  it('is a quoted ETag value', () => {
+    assert.match(payloadEtag({ generatedAt: 'z' }), /^"[a-f0-9]{32}"$/);
+  });
+});
+
+describe('webContentService.slugify', () => {
+  it('produces the slugs already in use on the live site', () => {
+    assert.equal(slugify('Estate fencing replacement'), 'estate-fencing-replacement');
+    assert.equal(slugify('Social value: our Jobs Plus partnership'), 'social-value-our-jobs-plus-partnership');
+  });
+
+  it('strips accents and punctuation rather than percent-encoding them', () => {
+    assert.equal(slugify('Café & Co.'), 'cafe-co');
+  });
+
+  it('never returns leading or trailing hyphens', () => {
+    assert.equal(slugify('  --Fencing--  '), 'fencing');
+  });
+});
+
+describe('webContentConfig', () => {
+  it('declares at most one richtext field per type', () => {
+    // layout.ejs binds Quill to hardcoded element ids, so a second editor on a
+    // page would silently write into the first one's hidden input and one of
+    // the two fields would save empty.
+    for (const [type, cfg] of Object.entries(webContentConfig)) {
+      const rich = cfg.fields.filter((f) => f.type === 'richtext');
+      assert.ok(rich.length <= 1, `${type} declares ${rich.length} richtext fields`);
+    }
+  });
+
+  it('never declares status or publishedAt as an editable field', () => {
+    // fields[] is the write whitelist. Declaring status here would let a form
+    // publish a record, bypassing the deliberate publish route.
+    for (const [type, cfg] of Object.entries(webContentConfig)) {
+      for (const forbidden of ['status', 'publishedAt', 'uuid', 'createdBy', 'updatedBy']) {
+        assert.ok(
+          !cfg.fields.some((f) => f.name === forbidden),
+          `${type} exposes ${forbidden} to the form`,
+        );
+      }
+    }
+  });
+
+  it('names a model and a label for every type', () => {
+    for (const [type, cfg] of Object.entries(webContentConfig)) {
+      assert.ok(cfg.model, `${type} has no model`);
+      assert.ok(cfg.label, `${type} has no label`);
+      assert.ok(Array.isArray(cfg.fields) && cfg.fields.length, `${type} has no fields`);
+    }
+  });
+});

--- a/tests/webMediaService.test.js
+++ b/tests/webMediaService.test.js
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import sharp from 'sharp';
+
+import { processImage, normaliseFilename, fileFilter, MAX_BYTES, MAX_EDGE } from '../services/webMediaService.js';
+
+/**
+ * The upload path for website photographs.
+ *
+ * Real sharp, no mocks: the assertions here are about what the encoder actually
+ * produces — a size ceiling, a dimension ceiling, and EXIF being gone — and a
+ * mocked encoder would assert only that the code calls the functions it calls.
+ */
+
+/** A noisy image, so the encoder cannot cheat the size limit on flat colour. */
+async function noisyJpeg(width, height) {
+  const px = Buffer.alloc(width * height * 3);
+  for (let i = 0; i < px.length; i += 1) px[i] = (i * 2654435761) % 256;
+  return sharp(px, { raw: { width, height, channels: 3 } }).jpeg({ quality: 100 }).toBuffer();
+}
+
+describe('webMediaService.processImage', () => {
+  it('brings a large photograph under the brief\'s 300KB ceiling', async () => {
+    const src = await noisyJpeg(3000, 2000);
+    assert.ok(src.length > MAX_BYTES, 'the fixture is not large enough to be a real test');
+    const out = await processImage(src, 'DSC_0001.JPG');
+    assert.ok(out.size <= MAX_BYTES, `output is ${out.size} bytes, over the ${MAX_BYTES} ceiling`);
+  });
+
+  it('caps the longest edge without distorting the image', async () => {
+    const out = await processImage(await noisyJpeg(3000, 2000), 'wide.jpg');
+    assert.ok(out.width <= MAX_EDGE && out.height <= MAX_EDGE);
+    // 3:2 in, 3:2 out.
+    assert.ok(Math.abs(out.width / out.height - 1.5) < 0.01, 'aspect ratio changed');
+  });
+
+  it('does not enlarge a small image', async () => {
+    // A logo upscaled to 2000px is a blurry logo, not a better one.
+    const out = await processImage(await noisyJpeg(320, 200), 'logo.png');
+    assert.equal(out.width, 320);
+    assert.equal(out.height, 200);
+  });
+
+  it('strips EXIF, including GPS', async () => {
+    // Site photographs are taken on phones on customers' estates. Publishing
+    // their coordinates would put a housing association's property on a map.
+    const withExif = await sharp(await noisyJpeg(800, 600))
+      .withMetadata({ exif: { IFD0: { Copyright: 'HCS' }, GPS: { GPSLatitudeRef: 'N' } } })
+      .jpeg()
+      .toBuffer();
+    const out = await processImage(withExif, 'estate.jpg');
+    const meta = await sharp(out.bytes).metadata();
+    assert.ok(!meta.exif, 'EXIF survived the re-encode');
+  });
+
+  it('converts to WebP and normalises the filename', async () => {
+    const out = await processImage(await noisyJpeg(600, 400), 'fence complete 5.jpeg');
+    assert.equal(out.mime, 'image/webp');
+    assert.equal(out.filename, 'fence-complete-5.webp');
+  });
+
+  it('hashes the output, so the same source twice is the same image', async () => {
+    const src = await noisyJpeg(600, 400);
+    const a = await processImage(src, 'a.jpg');
+    const b = await processImage(src, 'b.jpg');
+    assert.equal(a.hash, b.hash, 'identical bytes produced different hashes');
+    assert.match(a.hash, /^[a-f0-9]{64}$/);
+  });
+});
+
+describe('webMediaService.normaliseFilename', () => {
+  it('removes the spaces the live site\'s images are full of', () => {
+    assert.equal(normaliseFilename('Living wage LOGO.png'), 'living-wage-logo.webp');
+    assert.equal(normaliseFilename('fence almost done 3.jpeg'), 'fence-almost-done-3.webp');
+  });
+
+  it('always produces a name', () => {
+    assert.equal(normaliseFilename(''), 'image.webp');
+    assert.equal(normaliseFilename('***.png'), 'image.webp');
+  });
+});
+
+describe('webMediaService.fileFilter', () => {
+  const call = (originalname, mimetype) => new Promise((resolve) => {
+    fileFilter({}, { originalname, mimetype }, (err, ok) => resolve({ err, ok }));
+  });
+
+  it('accepts the formats a phone or camera produces', async () => {
+    for (const [name, mime] of [['a.jpg', 'image/jpeg'], ['a.jpeg', 'image/jpeg'], ['a.png', 'image/png'], ['a.webp', 'image/webp']]) {
+      const { err, ok } = await call(name, mime);
+      assert.ok(ok && !err, `${name} was rejected`);
+    }
+  });
+
+  it('rejects SVG', async () => {
+    // These bytes are mirrored and served by heroncs.co.uk. An SVG is a
+    // script-bearing document, not an image.
+    const { err, ok } = await call('logo.svg', 'image/svg+xml');
+    assert.ok(err && !ok);
+  });
+
+  it('rejects a mismatch between extension and declared type', async () => {
+    const { err } = await call('payload.php', 'image/jpeg');
+    assert.ok(err, 'a .php with an image mime was accepted');
+  });
+});

--- a/tests/websiteRoutesGuards.test.js
+++ b/tests/websiteRoutesGuards.test.js
@@ -1,0 +1,166 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import rbac from '../mongoose/config/rolePermissionsConfig.js';
+import departmentsConfig from '../mongoose/config/departmentsConfig.js';
+import tilesConfig from '../mongoose/config/dashboardTilesConfig.js';
+import webContentConfig from '../mongoose/config/webContentConfig.js';
+
+/**
+ * Config-consistency checks for the website content editor. No database, no
+ * HTTP — the same shape as bankRoutesGuards.test.js, and for the same reason:
+ * what publishes to the public internet is decided across a routes file, an
+ * RBAC config, a department registry and a content config, and the failure mode
+ * of those disagreeing is silent.
+ *
+ * The checks that matter most here are the two about the *public* API: it is
+ * the only route surface in this app that answers without a session, so the
+ * things keeping it safe — a token, GET-only, no broader public prefix — are
+ * pinned rather than left to review.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const webRoutesSrc = read('mongoose/routes/webRoutes.js');
+const apiRoutesSrc = read('mongoose/routes/webApiRoutes.js');
+const apiCtrlSrc = read('mongoose/controllers/webApiController.js');
+const authSrc = read('services/authService.js');
+const controllerSrc = read('mongoose/controllers/webController.js');
+
+/** Every route webRoutes.js registers: method, path, and the guard named first. */
+function declaredRoutes(src) {
+  const re = /router\.(get|post)\(\s*'([^']+)'\s*,\s*(\.\.\.)?(\w+)/g;
+  const out = [];
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    out.push({ method: m[1], path: m[2], guard: m[4] });
+  }
+  return out;
+}
+
+describe('website editor routes / permissions consistency', () => {
+  const routes = declaredRoutes(webRoutesSrc);
+
+  it('registers the expected surface', () => {
+    const paths = routes.map((r) => r.path);
+    for (const expected of [
+      '/website/settings',
+      '/website/media',
+      '/website/media/:uuid/file',
+      '/website/:type',
+      '/website/:type/create',
+      '/website/:type/:uuid/edit',
+      '/website/:type/:uuid/publish',
+      '/website/:type/:uuid/unpublish',
+      '/website/:type/:uuid/delete',
+    ]) {
+      assert.ok(paths.includes(expected), `missing route ${expected}`);
+    }
+  });
+
+  it('guards every editor route with adminOnly', () => {
+    for (const r of routes) {
+      assert.equal(r.guard, 'adminOnly', `${r.method.toUpperCase()} ${r.path} is not admin-guarded`);
+    }
+  });
+
+  it('registers the singleton and media routes before the generic :type routes', () => {
+    // Express matches in declaration order. '/website/settings' would otherwise
+    // be swallowed by '/website/:type' and resolve as a content type named
+    // "settings" — which exists, and would render a list page for a singleton.
+    const genericIdx = webRoutesSrc.indexOf("router.get('/website/:type'");
+    for (const specific of ["router.get('/website/settings'", "router.get('/website/media'"]) {
+      const idx = webRoutesSrc.indexOf(specific);
+      assert.ok(idx > -1 && idx < genericIdx, `${specific} must be registered before /website/:type`);
+    }
+  });
+
+  it('validates CSRF after multer on the media upload', () => {
+    // The global CSRF middleware cannot read a multipart body, so validation
+    // has to run again once multer has parsed it — after, never before, or it
+    // reads an empty body and rejects every upload.
+    const uploadArray = controllerSrc.match(/export const postMediaUpload = \[([\s\S]*?)\]/);
+    assert.ok(uploadArray, 'postMediaUpload middleware array not found');
+    const body = uploadArray[1];
+    const multerIdx = body.indexOf("upload.single('image')");
+    const csrfIdx = body.indexOf('csrfService.validate');
+    assert.ok(multerIdx > -1, 'no multer middleware on the upload');
+    assert.ok(csrfIdx > -1, 'no CSRF validation on the upload');
+    assert.ok(multerIdx < csrfIdx, 'csrfService.validate must run AFTER multer');
+  });
+
+  it("routeAccess grants '/website' to admin only", () => {
+    const matched = rbac.matchRoutePattern('/website/case-studies');
+    assert.equal(matched, '/website');
+    assert.ok(rbac.canAccessRoute('admin', matched, {}));
+    for (const role of ['accountant', 'employee', 'subcontractor', 'client', 'hmrc', 'auditor', 'none']) {
+      assert.ok(!rbac.canAccessRoute(role, matched, {}), `${role} can reach /website`);
+    }
+  });
+
+  it('has a website department that only admin can open', () => {
+    assert.ok(departmentsConfig.website, 'no website department');
+    assert.deepEqual(departmentsConfig.website.roles, ['admin']);
+  });
+
+  it('points every website dashboard tile at a route that exists', () => {
+    // The 6.26.0 changelog records a tile that advertised a 404 for months
+    // because the link and the route are declared in different files.
+    const tiles = Object.values(tilesConfig).filter((t) => (t.department || []).includes('website'));
+    assert.ok(tiles.length >= 5, `only ${tiles.length} website tiles`);
+    const types = Object.keys(webContentConfig);
+    for (const tile of tiles) {
+      const segment = tile.link.replace('/website/', '');
+      const known = segment === 'media' || segment === 'settings' || types.includes(segment);
+      assert.ok(known, `tile "${tile.title}" links to ${tile.link}, which no route serves`);
+    }
+  });
+});
+
+describe('public website content API', () => {
+  const routes = declaredRoutes(apiRoutesSrc);
+
+  it('is GET-only', () => {
+    // A POST here would inherit the PUBLIC_PREFIXES bypass below while having
+    // no CSRF protection, since this router deliberately carries none.
+    assert.ok(routes.length > 0, 'no API routes found');
+    for (const r of routes) {
+      assert.equal(r.method, 'get', `${r.path} is not a GET`);
+    }
+  });
+
+  it('requires the bearer token on every route', () => {
+    for (const r of routes) {
+      const line = apiRoutesSrc.split('\n').find((l) => l.includes(`'${r.path}'`));
+      assert.match(line, /requireWebApiToken/, `${r.path} has no token guard`);
+    }
+  });
+
+  it('rate-limits every route', () => {
+    for (const r of routes) {
+      const line = apiRoutesSrc.split('\n').find((l) => l.includes(`'${r.path}'`));
+      assert.match(line, /webApiLimiter/, `${r.path} is not rate-limited`);
+    }
+  });
+
+  it('fails closed when WEB_API_TOKEN is unset', () => {
+    // An unconfigured deployment must refuse, not serve. A 200 to the whole
+    // internet is the outcome this asserts against.
+    assert.match(apiCtrlSrc, /if \(!expected\)[\s\S]{0,200}res\.status\(503\)/);
+  });
+
+  it('only ever exposes published records', () => {
+    assert.match(apiCtrlSrc, /status: 'published'/, 'media route does not filter on status');
+  });
+
+  it("makes '/api/web/' public and nothing broader", () => {
+    // Anything under this prefix skips ensureAuthenticated. The 6.x incident
+    // recorded in authService.js was a prefix one segment too short.
+    assert.ok(authSrc.includes('"/api/web/"'), 'the API prefix is not public');
+    assert.ok(!authSrc.includes('"/api/"'), '"/api/" would expose every API route');
+  });
+});

--- a/tests/websiteViews.test.js
+++ b/tests/websiteViews.test.js
@@ -1,0 +1,150 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ejs from 'ejs';
+
+import webContentConfig from '../mongoose/config/webContentConfig.js';
+
+/**
+ * Renders every website-editor view with full and minimal data.
+ *
+ * These views are generic over webContentConfig, which is the reason to render
+ * them per type rather than once: a field type added to the config with no
+ * branch in _field.ejs renders as nothing at all — a form that silently drops
+ * whatever someone typed into it — and only a render across every declared
+ * field would catch that.
+ *
+ * The CSP assertions are the same set bankViews.test.js makes: Helmet blocks
+ * inline scripts and handlers at runtime, so a violation shows up as a quietly
+ * broken page rather than an error.
+ */
+
+const VIEWS = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'mongoose/views/tailwindcss/website');
+
+const MEDIA = [
+  { uuid: 'm1', filename: 'fence-complete-5.webp', mime: 'image/webp', width: 1600, height: 1067, size: 210000, alt: 'Completed fencing' },
+  { uuid: 'm2', filename: 'fence-before.webp', mime: 'image/webp', width: 1600, height: 1067, size: 190000, alt: '' },
+];
+
+/** A record with every field populated, whatever the type. */
+function fullRecord(cfg) {
+  const record = { uuid: 'r-1', slug: 'a-slug', status: 'published', publishedAt: new Date('2026-03-05') };
+  for (const field of cfg.fields) {
+    switch (field.type) {
+      case 'number': record[field.name] = 3; break;
+      case 'date': record[field.name] = new Date('2027-01-31'); break;
+      case 'tags': record[field.name] = ['news', 'company']; break;
+      case 'image': record[field.name] = { media: 'm1', alt: 'Completed fencing' }; break;
+      case 'panel': record[field.name] = { media: 'm2', alt: 'Damaged fencing', caption: 'Due for replacement.' }; break;
+      case 'gallery': record[field.name] = [{ media: 'm1', alt: 'Panels going in', caption: '' }]; break;
+      case 'hours': record[field.name] = [{ days: 'Monday – Friday', time: '8:00am – 5:00pm' }]; break;
+      case 'offices': record[field.name] = [{ label: 'Liverpool office', phone: '0151 475 1217', address: { line1: '103 Herondale Road', line3: 'Liverpool', postcode: 'L18 1JZ' } }]; break;
+      case 'richtext': record[field.name] = '<p>Some copy.</p>'; break;
+      default: record[field.name] = 'A value';
+    }
+  }
+  return record;
+}
+
+const render = (view, data) => ejs.renderFile(path.join(VIEWS, `${view}.ejs`), { csrfToken: 'tok', ...data });
+
+function assertClean(html, what) {
+  assert.ok(html.length > 50, `${what} rendered almost nothing`);
+  assert.ok(!/<script/i.test(html), `${what} contains a <script> tag`);
+  assert.ok(!/<style/i.test(html), `${what} contains a <style> tag`);
+  assert.ok(!/\son(click|change|submit|load|input)\s*=/i.test(html), `${what} contains an inline event handler`);
+  assert.ok(!/\b(fetch|XMLHttpRequest|axios)\s*\(/.test(html), `${what} makes a browser network call`);
+  for (const tag of ['<html', '<head', '<body', '<nav']) {
+    assert.ok(!html.toLowerCase().includes(tag), `${what} contains ${tag} — views are fragments`);
+  }
+}
+
+describe('website editor views', () => {
+  for (const [type, cfg] of Object.entries(webContentConfig)) {
+    describe(`${type} form`, () => {
+      it('renders a populated record', async () => {
+        const html = await render('form', { type, cfg, record: fullRecord(cfg), media: MEDIA, title: 'T' });
+        assertClean(html, `${type} form (full)`);
+      });
+
+      it('renders an empty create form', async () => {
+        const html = await render('form', { type, cfg, record: null, media: MEDIA, title: 'T' });
+        assertClean(html, `${type} form (create)`);
+      });
+
+      it('renders with no media in the library', async () => {
+        // The first person to use this has an empty library, and the pickers
+        // must still render rather than throwing on an empty list.
+        const html = await render('form', { type, cfg, record: null, media: [], title: 'T' });
+        assertClean(html, `${type} form (no media)`);
+      });
+
+      it('renders an input for every declared field', async () => {
+        const html = await render('form', { type, cfg, record: fullRecord(cfg), media: MEDIA, title: 'T' });
+        for (const field of cfg.fields) {
+          assert.ok(
+            html.includes(`name="${field.name}"`) || html.includes(`name="${field.name}[`),
+            `${type}: field "${field.name}" (${field.type}) has no input — the form would drop it silently`,
+          );
+        }
+      });
+
+      it('includes a CSRF token in every form', async () => {
+        const html = await render('form', { type, cfg, record: fullRecord(cfg), media: MEDIA, title: 'T' });
+        const forms = html.match(/<form[^>]*method="POST"/gi) || [];
+        const tokens = html.match(/name="_csrf"/g) || [];
+        assert.ok(forms.length > 0, 'no POST form rendered');
+        assert.equal(tokens.length, forms.length, 'a POST form is missing its CSRF token');
+      });
+    });
+
+    if (!cfg.singleton) {
+      describe(`${type} list`, () => {
+        const records = [
+          { uuid: 'r-1', slug: 'a', status: 'published', title: 'A study', name: 'A body', client: 'Plus Dane' },
+          { uuid: 'r-2', slug: 'b', status: 'draft', title: 'A draft', name: 'A draft' },
+        ];
+
+        it('renders rows', async () => {
+          const html = await render('list', { type, cfg, records, titleField: 'title', title: 'T' });
+          assertClean(html, `${type} list`);
+        });
+
+        it('renders empty', async () => {
+          const html = await render('list', { type, cfg, records: [], titleField: 'title', title: 'T' });
+          assertClean(html, `${type} list (empty)`);
+        });
+
+        it('distinguishes live from draft', async () => {
+          const html = await render('list', { type, cfg, records, titleField: 'title', title: 'T' });
+          assert.match(html, /Live/, 'published records are not marked live');
+          assert.match(html, /Draft/, 'draft records are not marked draft');
+        });
+      });
+    }
+  }
+
+  describe('media library', () => {
+    it('renders with images', async () => {
+      const html = await render('media', { media: MEDIA, maxBytes: 307200, title: 'M' });
+      assertClean(html, 'media library');
+    });
+
+    it('renders empty', async () => {
+      const html = await render('media', { media: [], maxBytes: 307200, title: 'M' });
+      assertClean(html, 'media library (empty)');
+    });
+
+    it('flags an image with no alt text', async () => {
+      // The brief is explicit that alt text is real content, not decoration.
+      const html = await render('media', { media: MEDIA, maxBytes: 307200, title: 'M' });
+      assert.match(html, /No alt text/);
+    });
+
+    it('posts as multipart', async () => {
+      const html = await render('media', { media: [], maxBytes: 307200, title: 'M' });
+      assert.match(html, /enctype="multipart\/form-data"/);
+    });
+  });
+});


### PR DESCRIPTION
> This is the `CHANGELOG.md` entry for 6.27.0, inline. The changelog is the single description of this release — if anything below changes, change it there.

Pairs with [hcs-web#7](https://github.com/CappyTech/hcs-web/pull/7)

### Added
- **A website content editor at `/website`, and a read-only API the public site pulls from.** Every content file in [hcs-web](https://github.com/CappyTech/hcs-web) — `blogData.js`, `caseStudyData.js`, `servicesData.js`, `accreditationsData.js`, `siteData.js` — carries the same comment: *"Swap this in-memory array for a DB/CMS later without touching the service, controller, or views."* Until now a copy change was a developer, a commit, and a manual **Update from Remote → Deploy HEAD Commit** in cPanel. The Website Design Brief asks the site to be evidence rather than advertising — real projects, real accreditations, `[TO SUPPLY]` wherever a fact is missing — and the people who can fill those gaps are not the people who can run `git push`.

  **hcs-web is a cache of this data, not a client of it.** It pulls the payload, writes it to disk and serves the public site from that copy, so heroncs.co.uk keeps working with hcs-app switched off entirely — which is what makes it safe to put the company's public site behind a service on a domestic connection. hcs-app being reachable governs *editing*, never *serving*. Nothing here should acquire a behaviour that assumes the consumer is live at the moment of a change; the revalidate hook in `webRevalidateService.js` is an optimisation over the consumer's own polling and is deliberately fire-and-forget.

- **A fourth Mongo namespace, `WEB`** (`MONGO_DBNAME_WEB`, default `hcs-webdb`), holding six models: `webCaseStudy`, `webPost`, `webService`, `webAccreditation`, `webSiteSettings` and `webMedia`.

  **The `hcs_app` Mongo user needs `readWrite` + `dbAdmin` on the new database.** It is scoped to `rest-kashflowdb`, `kashflowdb` and `paperless-kashflowdb`; without the grant the app connects and then every write fails `Unauthorized`. That is the step most likely to be missed on deploy, and the symptom does not name the cause.

  `auditPlugin` now attaches to `WEB` as well as `INTERNAL`. It was INTERNAL-only, so a new namespace would have had no audit trail at all — and "who changed this published copy, and when" is the whole point of an editorial trail. The plugin's `sanitize()` already renders Buffers as `[Buffer N bytes]`, so this does not copy every photograph into the audit log.

- **Draft/publish per record, with publishing on its own route.** `status` is not a form field: `webContentConfig.fields[]` is the write whitelist and the controller builds every update from it, so a record cannot be pushed onto the public internet by adding a hidden input. `publishedAt` is stamped once, on first publication — it is the date the site displays, not a "last touched" timestamp, so fixing a typo does not move an article back to the top of the blog.

- **Images are stored in Mongo, resized on upload.** The storage volume at `~/docker/app/storage` is in **none** of the five nightly backup jobs while Mongo is dumped at 02:00, so bytes in Mongo are backed up, survive a `docker compose pull` redeploy, and need no sixth cron job.

  `sharp` is a new dependency — the app had no image processing of any kind. Uploads are re-encoded to WebP down a ladder that steps **quality first, then dimensions**, because quality alone does not converge: pure noise at the old floor still came out at 634KB against the brief's 300KB ceiling, and foliage, gravel and brickwork — most of what this company photographs — compress much like noise. **EXIF is stripped**, which matters more than it sounds: these photographs are taken on phones on customers' estates, and EXIF carries GPS coordinates. **SVG is rejected**, unlike the letterhead upload it is otherwise modelled on: these bytes are mirrored and served by heroncs.co.uk, and an SVG is a script-bearing document.

### Changed
- **`WEB` is reported by `/healthz` but is not part of `ok`, and is excluded from `maintenanceService.dbState()`.** `mdb.connect()` awaits all four connections, so a misconfigured namespace fails loudly at boot; losing it later must not mark the container unhealthy or 503 CIS, payroll and attendance over marketing copy. The models are also not registered with the generic CRUD/list controllers, which iterate REST and INTERNAL — website content is edited only through `/website`, which owns the draft/publish gate.

- **The Quill initialiser in `layout.ejs` now binds `closest('form')`** rather than the hardcoded `#policy-form`, so any page opting in with `quillEditor: true` works without registering its form id there. It is still **one editor per page** — the `#quill-editor`, `#quill-toolbar` and `#contentHtml-input` ids are hardcoded, and a second instance would silently write into the first one's hidden input, saving one of the two fields empty. `tests/webContentService.test.js` asserts no content type declares more than one `richtext` field.

### Notes
Three things worth knowing before touching this next.

- **The API is the only route surface in this app that answers without a session.** `"/api/web/"` is in `PUBLIC_PREFIXES`, so everything under it skips `ensureAuthenticated` — the same shape as the `/resources/` prefix that once silently defeated that guard. It is GET-only, token-guarded and rate-limited, and `tests/websiteRoutesGuards.test.js` pins all three plus the prefix itself. A POST added there would inherit the bypass while carrying no CSRF protection.
- **The token fails closed.** With `WEB_API_TOKEN` unset the endpoint answers 503 rather than serving: an unconfigured deployment that refuses is a problem someone notices, one that answers 200 to the whole internet is not.
- **The path may not contain `db`, `backup` or `database`, or end `.zip`/`.gz`/`.sql`.** `requestBlocklistService` 403s those *and* counts them toward a one-hour autoban of the caller — which, here, would be the public website.

`scripts/seed-web-content.js --from ~/code/hcs-web` imports the live site's content and its 7.3MB of photographs, idempotent by slug and by image hash, so the editor opens on the real site rather than an empty one. It takes a path rather than bundling a fixture, so the photographs are not carried in every image build for the sake of a script that runs once.

### Verification
Run against a throwaway `mongo:8.0`, never the production database.

- **1285 tests pass**, up from 1205 — new coverage for the route guards, the payload, the image pipeline, and every view at every declared field.
- The seed imported the live site whole: 10 images, 2 case studies, 1 post, 6 services, 5 accreditations, site settings. `Living wage LOGO.png` came down from 321KB to 90KB.
- The API answered 401 without a token, 200 with, 304 on a matching ETag, and carried no image bytes in the manifest.
- **Unpublishing a case study removed it from the payload** on the next request.
- hcs-web pulled it and rendered every page; **with this app killed and hcs-web restarted, every page still rendered, images included**, from its disk mirror. Deleting the mirror fell through to the seed arrays.

### Deploying
1. Grant the Mongo user `readWrite` + `dbAdmin` on `hcs-webdb` (above).
2. `MONGO_DBNAME_WEB` and `WEB_API_TOKEN` in `docker/app/compose.env` — `env_file:` vars need `docker compose up -d`, not `restart`.
3. Deploy, then check the log for the WEB connection opening and no `Unauthorized`.
4. `node scripts/seed-web-content.js --from ~/code/hcs-web` once.
5. Then the hcs-web side.

hcs-web is safe to deploy at any point: with no token or no API it serves its built-in seed content, which is what the site shows today. There is no window where the public site is broken.
