### PR TITLE
fix: retry the Paperless request when a stale Accept version 406s (6.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.28.1] - 2026-08-21
+
+### Fixed
+- **Every Paperless call was failing with HTTP 406, because the Accept header named an API version Paperless had retired.** `paperlessClient.js` asks for `application/json; version=6`; paperless-ngx 3.0.5 dropped API versions 1-8 and serves only 9 and 10, so DRF answered `406 {"detail":"Invalid version in \"Accept\" header."}` to everything at once — `GET /documents/`, `GET /custom_fields/`, `[bankStatementIngest] listing documents failed` on each 6-hourly run, and `Grab failed: Request failed with status code 406` from `/paperless/ingest`.
+
+  The client already had the fallback for this: it retries once **without** the Accept header, letting the server pick its own default version. It only fired on a **400**. Some installs do answer 400, but DRF's `AcceptHeaderVersioning` answers **406**, which is the case that actually occurs — so nothing self-healed and the integration simply stopped. The retry now covers 400 and 406 alike, drops both header spellings, and logs at **warn** naming the rejected value and `PAPERLESS_ACCEPT`; it was previously silent unless `PAPERLESS_VERBOSE` was on, and a silent version drift takes the whole Paperless integration down with no line in the log saying why.
+
+  `tests/paperlessClient.test.js` drives a real HTTP server for this rather than reading the source, because what matters is the retry *completing* — the interceptor is registered on an axios instance built inside `makeClient()`. It also pins that the fallback gives up after one attempt when the unversioned request is refused too, so a server that 406s everything cannot put the client in a loop.
+
+  **The header should still be pinned to a version the server serves** — the fallback is a net, not the fix. `PAPERLESS_ACCEPT=application/json; version=10` is set on the deployment, and `compose.env.example` now explains why the value goes stale. Version 9 differs from 10 only by an extra `all` array of every matching id in list responses, which nothing here reads; `custom_fields` entries are `{field:<int>, value}` in both, the shape `updateDocumentCustomFields` expects.
+
 ## [6.28.0] - 2026-08-19
 
 ### Changed

--- a/compose.env.example
+++ b/compose.env.example
@@ -242,7 +242,11 @@ PAPERLESS_TOKEN=your-paperless-token
 # used by: `mongoose/services/paperless/paperlessClient.js` (SSH tunnel toggle)
 # PAPERLESS_SSH_TUNNEL_ENABLED=false
 # used by: `mongoose/services/paperless/paperlessClient.js` (Accept header)
-# PAPERLESS_ACCEPT=application/json; version=6
+# Pin the Paperless API version this app asks for. Paperless retires old versions:
+# 3.0.5 serves only 9 and 10, and a version it no longer serves answers HTTP 406
+# on every call. The client retries once without the header when that happens, but
+# set this to a version the server actually serves rather than relying on that.
+# PAPERLESS_ACCEPT=application/json; version=10
 # used by: `mongoose/services/paperless/paperlessClient.js` (HTTP request timeout in ms, default 60000)
 # PAPERLESS_TIMEOUT_MS=60000
 # used by: `mongoose/services/paperless/grabServicePaperless.js`, `mongoose/controllers/paperlessController.js`

--- a/mongoose/services/paperless/paperlessClient.js
+++ b/mongoose/services/paperless/paperlessClient.js
@@ -221,24 +221,31 @@ function makeClient() {
           `[paperlessClient] HTTP ${status} on ${error?.config?.method?.toUpperCase?.() || ""} ${error?.config?.url || ""}${dataSnippet}`,
         );
       }
+      // A versioned Accept header that the server will not serve is reported two
+      // different ways: some installs answer 400, and DRF's AcceptHeaderVersioning
+      // answers **406 Not Acceptable** ({"detail":"Invalid version in \"Accept\"
+      // header."}) once the requested version leaves ALLOWED_VERSIONS. Paperless-ngx
+      // 3.0.5 retired API versions 1-8, which turned this client's default
+      // `version=6` into a 406 on *every* call at once. Retry without the header so
+      // the server falls back to its own default version, and say so at warn level:
+      // the only symptom otherwise is that everything Paperless-shaped stops working.
       if (
-        status === 400 &&
+        (status === 400 || status === 406) &&
         error?.config &&
         !error.config.__acceptFallbackTried
       ) {
-        // Some Paperless installs reject versioned Accept header; retry once without version
         const retryCfg = {
           ...error.config,
           headers: { ...(error.config.headers || {}) },
         };
+        const requestedAccept =
+          retryCfg.headers.Accept || retryCfg.headers.accept || "";
         delete retryCfg.headers.Accept;
+        delete retryCfg.headers.accept;
         retryCfg.__acceptFallbackTried = true;
-        if (process.env.PAPERLESS_VERBOSE === "true" || process.env.DEBUG) {
-          logger.warn(
-            "[paperlessClient] 400 received; retrying without Accept header for %s",
-            retryCfg.url || retryCfg.baseURL,
-          );
-        }
+        logger.warn(
+          `[paperlessClient] HTTP ${status} with Accept "${requestedAccept}"; retrying without it for ${retryCfg.url || retryCfg.baseURL}. Set PAPERLESS_ACCEPT to a version this Paperless still serves.`,
+        );
         try {
           return await axios(retryCfg);
         } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.28.0",
+      "version": "6.28.1",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/tests/paperlessClient.test.js
+++ b/tests/paperlessClient.test.js
@@ -1,0 +1,107 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+/**
+ * The Accept header this client sends names a Paperless API version, and
+ * Paperless retires old versions: 3.0.5 serves only 9 and 10, which turned the
+ * built-in default of `version=6` into an HTTP 406 on every call at once —
+ * document listing, custom fields, the 6-hourly bank-statement ingest, the lot.
+ *
+ * These drive a real server rather than reading the source, because what matters
+ * is the retry actually completing: the fallback is registered on an axios
+ * instance built inside makeClient(), so a source assertion would not catch it
+ * being registered on the wrong instance or after the request is issued.
+ */
+describe('paperlessClient Accept-version fallback', () => {
+  let server;
+  let baseURL;
+  /** @type {Array<{url: string, accept: string|undefined}>} */
+  let received = [];
+  /** Status returned while an Accept header naming a version is present. */
+  let rejectVersionedWith = 406;
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      const accept = req.headers.accept;
+      received.push({ url: req.url, accept });
+      if (accept && /version=/.test(accept)) {
+        res.writeHead(rejectVersionedWith, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ detail: 'Invalid version in "Accept" header.' }));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ count: 1, next: null, results: [{ id: 42 }] }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    baseURL = `http://127.0.0.1:${server.address().port}/api`;
+
+    process.env.PAPERLESS_TOKEN = 'test-token';
+    process.env.PAPERLESS_BASE_URL = baseURL;
+    process.env.PAPERLESS_SSH_TUNNEL_ENABLED = 'false';
+  });
+
+  after(() => new Promise((resolve) => server.close(resolve)));
+
+  const freshClient = async () => {
+    const mod = await import('../mongoose/services/paperless/paperlessClient.js');
+    return mod.default.makeClient();
+  };
+
+  it('retries without the Accept header when the server answers 406', async () => {
+    received = [];
+    rejectVersionedWith = 406;
+    process.env.PAPERLESS_ACCEPT = 'application/json; version=6';
+
+    const client = await freshClient();
+    const data = await client.listDocuments({ page: 1, pageSize: 1 });
+
+    assert.equal(data.count, 1, 'the retry should have returned the real payload');
+    assert.equal(received.length, 2, 'expected one rejected call and one retry');
+    assert.match(received[0].accept, /version=6/);
+    assert.ok(
+      !received[1].accept || !/version=/.test(received[1].accept),
+      `retry still carried a versioned Accept: ${received[1].accept}`,
+    );
+  });
+
+  it('still retries on 400, which some installs answer instead', async () => {
+    received = [];
+    rejectVersionedWith = 400;
+    process.env.PAPERLESS_ACCEPT = 'application/json; version=6';
+
+    const client = await freshClient();
+    const data = await client.listDocuments({ page: 1, pageSize: 1 });
+
+    assert.equal(data.count, 1);
+    assert.equal(received.length, 2);
+  });
+
+  it('does not retry forever when the server rejects the unversioned request too', async () => {
+    received = [];
+    rejectVersionedWith = 406;
+    process.env.PAPERLESS_ACCEPT = 'application/json; version=6';
+
+    // A server that 406s regardless of what is asked for: the fallback must give
+    // up after one attempt rather than looping.
+    const strict = http.createServer((req, res) => {
+      received.push({ url: req.url, accept: req.headers.accept });
+      res.writeHead(406, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ detail: 'Invalid version in "Accept" header.' }));
+    });
+    await new Promise((resolve) => strict.listen(0, '127.0.0.1', resolve));
+    process.env.PAPERLESS_BASE_URL = `http://127.0.0.1:${strict.address().port}/api`;
+
+    try {
+      const client = await freshClient();
+      await assert.rejects(
+        () => client.listDocuments({ page: 1, pageSize: 1 }),
+        /406/,
+      );
+      assert.equal(received.length, 2, 'expected exactly one retry, then failure');
+    } finally {
+      process.env.PAPERLESS_BASE_URL = baseURL;
+      await new Promise((resolve) => strict.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
## What broke

Every Paperless call on the deployment was returning **HTTP 406** — `GET /documents/`, `GET /custom_fields/`, `[bankStatementIngest] listing documents failed` on each 6-hourly run, and `Grab failed: Request failed with status code 406` from `/paperless/ingest`.

`paperlessClient.js` sends `Accept: application/json; version=6`. **paperless-ngx 3.0.5 retired API versions 1–8** and serves only **9 and 10**, so DRF's `AcceptHeaderVersioning` answered `406 {"detail":"Invalid version in \"Accept\" header."}` to everything at once. Probed against the live instance:

| version | 1–8 | 9 | 10 | 11 | none |
| --- | --- | --- | --- | --- | --- |
| status | 406 | 200 | 200 | 406 | 200 |

## Why it did not self-heal

The client already carries the fallback for this — retry once **without** the Accept header so the server picks its own default version — but it fired only on a **400**. Some installs do answer 400; DRF answers **406**, which is the case that actually occurs. So the guard written for this exact failure mode sat right next to it and missed it.

## The change

- The retry now covers **400 and 406** alike, and deletes both header spellings (`Accept` / `accept`) before retrying.
- It logs at **warn** naming the rejected value and `PAPERLESS_ACCEPT`. It was previously silent unless `PAPERLESS_VERBOSE` was on — and a stale version takes the whole Paperless integration down with nothing in the log saying why.
- `compose.env.example` documents that the pinned version goes stale as Paperless retires versions, with `version=10` as the current value.

## Tests

`tests/paperlessClient.test.js` drives a **real HTTP server** rather than asserting on the source: what matters is the retry *completing*, and the interceptor is registered on an axios instance built inside `makeClient()`, so a source assertion would not catch it being registered on the wrong instance or after the request is issued. Three cases:

1. a 406 on a versioned Accept is retried without it, and the payload arrives;
2. a 400 is still retried, for installs that answer that way;
3. a server that 406s **regardless** of what is asked for fails after exactly one retry — the fallback cannot loop.

Tests 1 and 3 fail against the pre-change client (verified by stashing it). Full suite: **1288 passed, 0 failed**, exit 0.

## Note on deployment

The fallback is a net, not the fix — the header should still name a version the server serves. `PAPERLESS_ACCEPT=application/json; version=10` is set in the deployment's `compose.env` and the container recreated; `/documents/` and `/custom_fields/` both return 200 through the app's own client. v9 differs from v10 only by an extra `all` array of every matching id in list responses, which nothing here reads; `custom_fields` entries are `{field:<int>, value}` in both — the shape `updateDocumentCustomFields` expects.