### PR TITLE
fix(security): set the security headers on every response, not just routed ones (6.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ All notable changes to hcs-app will be documented here. Format follows [Keep a C
 ### Changed
 - `connectionSettingsController.js` is now only the connection tester — 340 lines to 96. The settings pages live in `appConfigController.js`.
 
+## [6.29.1] - 2026-08-21
+
+### Fixed
+- **Security headers were mounted too low in the stack, so anything answered before the router carried none of them.** `generateNonce`, `permissionsPolicy` and `helmet` sat on `appRouter` beside the body sanitiser. Plenty of responses never get that far: `requestBlocklistService` answers a bare `403` to anything that looks like a scanner, and `/favicon.ico`, `/healthz` and the maintenance `503` are all served earlier. Those replies went out with **no CSP, no `X-Frame-Options` and no `X-Content-Type-Options`**.
+
+  A vulnerability scan reported exactly that — missing CSP, missing clickjacking protection, content sniffing allowed — while a headers scan of the same URL minutes earlier graded it A with all three present. Both were right: **92% of the scanner's requests were 403s**, because it tripped the blocklist, and it graded the responses it actually received. It also detected no technologies, for the same reason.
+
+  Reproduced by hitting a blocklisted path fourteen times from a container on `hcs-net` and then requesting `/`: `403 Forbidden`, `Content-Type`, `ETag`, `Date` — and nothing else.
+
+  The headers are now mounted at the top of the stack, immediately after `trust proxy` and `trustEdgeTls`, so every response carries them. **The body sanitiser deliberately stays on `appRouter`**: it rewrites `req.body` and so has to run after the body parsers, whereas headers only get later and less useful the further down they are mounted. `securityService`'s default export is unchanged for existing importers; the new `securityHeaders` and `xssSanitize` named exports are what `app.js` mounts.
+
 ## [6.29.0] - 2026-08-21
 
 ### Security

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ import cisMappings from './mongoose/config/cisMappings.js';
 import __socketService from './services/socketService.js';
 import createSessionService from './mongoose/services/sessionService.js';
 import __csrfService from './services/csrfService.js';
-import __securityService, { trustEdgeTls } from './services/securityService.js';
+import { trustEdgeTls, securityHeaders, xssSanitize } from './services/securityService.js';
 import __flashService from './services/flashService.js';
 import __passwordResetDraft from './services/passwordResetDraft.js';
 import __auditContextService from './mongoose/services/auditContextService.js';
@@ -136,6 +136,12 @@ const main = async () => {
   // run before the session middleware, which reads the scheme when it decides
   // whether to set the cookie at all.
   app.use(trustEdgeTls);
+
+  // Security response headers, mounted before anything that can answer a
+  // request — the blocklist's 403, /favicon.ico, /healthz and the maintenance
+  // 503 all reply without ever reaching appRouter, and used to carry no CSP,
+  // X-Frame-Options or X-Content-Type-Options at all.
+  app.use(securityHeaders);
   app.set('view engine', 'ejs');
   app.set('views', [path.join(__dirname, 'mongoose/views')]);
   app.set('layout', path.join('tailwindcss', 'layout'));
@@ -413,7 +419,9 @@ const main = async () => {
 
     // Core middleware
     appRouter.use(useragent.express());
-    appRouter.use(__securityService);
+    // Headers are mounted at the top of the stack (see above); this is the
+    // body sanitiser, which must run after the body parsers.
+    appRouter.use(xssSanitize);
     appRouter.use(__flashService);
     // Drop any carried-over reset password the moment the browser navigates
     // outside the password reset flow. Mounted after the /resources static

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.30.0",
+  "version": "6.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.30.0",
+      "version": "6.29.1",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.30.0",
+  "version": "6.29.1",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/services/securityService.js
+++ b/services/securityService.js
@@ -218,7 +218,24 @@ function trustEdgeTls(req, _res, next) {
   next();
 }
 
-const securityService = [
+/**
+ * The response headers, as their own array so they can be mounted at the very
+ * top of the stack.
+ *
+ * They used to be mounted on appRouter, alongside the body sanitiser — which
+ * meant every response produced *before* that router carried none of them. That
+ * is not a rare path: `requestBlocklistService` answers a bare `403` to
+ * anything that looks like a scanner, and `/favicon.ico`, `/healthz` and the
+ * maintenance `503` are all served earlier too. A scanner that trips the
+ * blocklist therefore gets 403s with no CSP, no `X-Frame-Options` and no
+ * `X-Content-Type-Options` — and reports the site as having none of them, which
+ * is exactly what happened (92% of one scan's requests were 403s).
+ *
+ * The sanitiser stays on appRouter: it rewrites req.body and so has to run
+ * after the body parsers, whereas headers only get later and less useful the
+ * further down they are mounted.
+ */
+const securityHeaders = [
   generateNonce,
   permissionsPolicy,
   helmet({
@@ -227,8 +244,9 @@ const securityService = [
     crossOriginEmbedderPolicy: false, // adjust if you need COEP
     hsts: enableHsts ? { maxAge: 15552000, includeSubDomains: true } : false,
   }),
-  xssSanitize,
 ];
 
-export { trustEdgeTls, PERMISSIONS_POLICY };
+const securityService = [...securityHeaders, xssSanitize];
+
+export { trustEdgeTls, PERMISSIONS_POLICY, securityHeaders, xssSanitize };
 export default securityService;

--- a/tests/securityHeaders.test.js
+++ b/tests/securityHeaders.test.js
@@ -1,7 +1,7 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
-import securityService, { trustEdgeTls, PERMISSIONS_POLICY } from '../services/securityService.js';
+import securityService, { trustEdgeTls, PERMISSIONS_POLICY, securityHeaders, xssSanitize } from '../services/securityService.js';
 
 /**
  * A securityheaders.com scan of https://app.heroncs.co.uk (2026-08-20) found the
@@ -22,6 +22,9 @@ describe('security headers', () => {
     app.use(trustEdgeTls);
     app.use(securityService);
     app.get('/probe', (req, res) => res.json({ secure: req.secure }));
+    // Stands in for requestBlocklistService, /favicon.ico, /healthz and the
+    // maintenance 503 — everything that answers before appRouter is reached.
+    app.use((_req, res) => res.status(403).type('text/plain').send('Forbidden'));
     server = app.listen(0, '127.0.0.1');
     await new Promise((resolve) => server.once('listening', resolve));
     origin = `http://127.0.0.1:${server.address().port}`;
@@ -71,5 +74,42 @@ describe('security headers', () => {
       const res = await fetch(`${origin}/probe`);
       assert.equal((await res.json()).secure, false);
     });
+  });
+});
+
+/**
+ * The headers have to be mounted above everything that can answer a request.
+ * Mounted on appRouter, as they were, a blocked scanner got bare 403s carrying
+ * no CSP, no X-Frame-Options and no X-Content-Type-Options — and reported the
+ * site as having none of them, off the back of 92% of its requests being 403s.
+ */
+describe('headers on responses that never reach the router', () => {
+  let server;
+  let origin;
+
+  before(async () => {
+    const app = express();
+    app.use(securityHeaders);
+    app.use((_req, res) => res.status(403).type('text/plain').send('Forbidden'));
+    server = app.listen(0, '127.0.0.1');
+    await new Promise((resolve) => server.once('listening', resolve));
+    origin = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  after(() => new Promise((resolve) => server.close(resolve)));
+
+  it('sets them on a 403 from before the router', async () => {
+    const res = await fetch(`${origin}/anything`);
+    assert.equal(res.status, 403);
+    for (const header of ['content-security-policy', 'x-frame-options', 'x-content-type-options', 'permissions-policy']) {
+      assert.ok(res.headers.get(header), `${header} missing on a pre-router 403`);
+    }
+  });
+
+  it('keeps the body sanitiser separate from the headers', () => {
+    // It rewrites req.body, so it has to stay after the body parsers on
+    // appRouter — while headers only get less useful the later they mount.
+    assert.ok(!securityHeaders.includes(xssSanitize), 'xssSanitize must not be mounted with the headers');
+    assert.equal(securityService[securityService.length - 1], xssSanitize);
   });
 });


### PR DESCRIPTION
Two scans of `https://app.heroncs.co.uk/` disagreed, and both were right.

| Scan | Verdict |
| --- | --- |
| securityheaders.com, 20 Aug 23:24 | Grade **A** — CSP, X-Frame-Options, X-Content-Type-Options all present |
| Vulnerability scan, 21 Aug 00:39 | **Missing CSP, missing clickjacking protection, content sniffing allowed** |

## What was actually happening

`generateNonce`, `permissionsPolicy` and `helmet` were mounted on **`appRouter`**, beside the body sanitiser. A great many responses never reach that router:

- `requestBlocklistService` answers a bare `403` to anything that looks like a scanner
- `/favicon.ico`, `/healthz`, and the maintenance `503` are all served earlier

The scanner crawled 16 URLs and **92% of its requests came back 403** — it tripped the blocklist almost immediately, then graded the responses it actually received. It also reported "no technologies detected", for the same reason. So the A grade was real (for `/` as a normal visitor) and so were the findings (for everything the scanner saw).

Reproduced from a container on `hcs-net` — fourteen requests to a blocklisted path, then `GET /`:

```
HTTP/1.1 403 Forbidden
Connection: close
Content-Type: text/plain; charset=utf-8
Content-Length: 9
ETag: W/"9-PatfYBLj4Um1qTm5zrukoLhNyPU"
Date: Fri, 21 Aug 2026 00:18:20 GMT
```

No CSP, no `X-Frame-Options`, no `X-Content-Type-Options`.

## The change

Headers are mounted at the top of the stack now, immediately after `trust proxy` and `trustEdgeTls`, so every response carries them regardless of what answers it.

**The body sanitiser deliberately stays on `appRouter`.** It rewrites `req.body`, so it has to run *after* the body parsers — whereas headers only get later and less useful the further down they are mounted. That asymmetry is the whole reason they were bundled together in the first place, and separating them is the fix.

`securityService`'s default export is unchanged for existing importers (`tests/xssSanitize.test.js` still takes the last element); `app.js` now mounts the new `securityHeaders` and `xssSanitize` named exports at their correct points.

## Tests

Two added to `tests/securityHeaders.test.js`: a real express app with `securityHeaders` mounted above a middleware that 403s, asserting CSP, X-Frame-Options, X-Content-Type-Options and Permissions-Policy all survive on a pre-router 403; and one pinning that `xssSanitize` is *not* in the headers array, so the two cannot be re-merged without failing.

Full suite: **1310 passed, 0 failed**, exit 0.

## Still outstanding from the same scan

The two `SSL cookie without Secure flag` findings (`hms.sid`, `hms.csrf`) are fixed by #81, which is merged but **not yet deployed** — it also needs `TRUST_EDGE_TLS=true` in the deployment's `compose.env`. Doing that next, and I will confirm against the live site.
