### PR TITLE
chore: correct the version after a merge-order collision (6.30.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.30.1] - 2026-08-21
+
+### Changed
+- **Version corrected after a merge-order collision.** The 6.29.1 header fix was branched from master before 6.30.0 landed, so when it merged second its `package.json` bump took the version *backwards* — master read 6.29.1 while carrying every 6.30.0 change. Nothing shipped wrong: CI publishes only `:latest` and `:sha-<short>`, never a version tag. But `docker exec <c> node -e "…package.json…"` is how this estate answers "what is actually deployed", and that answer was lower than the code. The 6.29.1 entry below is left as written, since it describes the change accurately; this bump just puts the version ahead of 6.30.0 again.
+
 ## [6.30.0] - 2026-08-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcs-app",
-  "version": "6.29.1",
+  "version": "6.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hcs-app",
-      "version": "6.29.1",
+      "version": "6.30.1",
       "license": "All rights reserved.",
       "dependencies": {
         "@cappytech/hcs-schemas": "github:CappyTech/hcs-schemas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.29.1",
+  "version": "6.30.1",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",


### PR DESCRIPTION
The 6.29.1 header fix (#83) was branched from master before 6.30.0 (#82) landed, so merging it second took `package.json` **backwards**: master read `6.29.1` while carrying every 6.30.0 change.

Nothing shipped wrong — CI publishes only `:latest` and `:sha-<short>`, never a version tag. But `docker exec <c> node -e "…package.json…"` is how this estate answers *what is actually deployed*, and that answer was lower than the code it was reporting on.

Bumps to **6.30.1**. The 6.29.1 changelog entry is left exactly as written — it describes its change accurately, and rewriting a shipped entry to paper over the ordering would be worse than recording what happened.

Suite: 1310 passed, 0 failed.