### PR TITLE
feat(mail): read-only inbound mail filtering log at /mail (6.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.32.0] - 2026-08-21
+
+### Added
+- **The inbound mail filtering log is now readable in the app, at `/mail` (admin only).** Inbound mail to heroncs.co.uk was being silently rejected by the SpamExperts/StrikeMail filter — Quarantine response was set to *Rejected*, so legitimate senders got a 550 and we never saw it. There was no local record of any of it, which made "did my email reach you?" a support ticket rather than a question anyone here could answer. The `mailsiem` collector on the host now receives a syslog line per filtering decision and writes one NDJSON file per day; this release is hcs-app's read-only window onto those files.
+
+  The page shows how much mail was stopped, **why** — `extra_class` is the filter's own account of a classification, and a run of identical reasons across unrelated senders is what a misconfigured quarantine response looks like from the outside — and a search across sender, recipient, sending IP, message-id and filtering id. `/mail/message/:id` shows every decision recorded under one filtering id: a message to several recipients is several decisions, and they can differ, so one recipient's mail can be delivered while another's is stopped.
+
+  **The log is deliberately not in Mongo, and must not be moved there.** These records are third-party personal data — every line names a sender and a recipient, including people who appear nowhere else in this system and never chose to deal with us — held under a 90-day rule enforced by a deletion job on the collector host. Mongo is dumped nightly with its own 90-day archive retention, and those archives are browsable, so ingesting would leave copies alive for up to ~180 days against a 90-day policy and take the deletion job out of the critical path. Reading the files keeps the collector the sole owner: when a day file is deleted it is gone everywhere, including here. `mailFilterLogService.js` touches no database and there is no model, no namespace and no Mongo grant to add — a test strips comments and asserts the service and controller contain no database call at all, because both files *explain* this decision in prose and matching the explanation rather than the code would fail the moment someone documented it properly.
+
+  Consequences of that choice, all deliberate. There is no index, so every query is a bounded scan: the window is capped at the collector's 90-day retention, each entry point takes an explicit day count, and the summary on the landing page uses its own narrower 7-day window rather than being widened by the search. A bare page load scans nothing and lists nothing — returning "the most recent hundred" would invite reading it as a complete list. Lines are filtered as **raw text before `JSON.parse`**, which is what makes this fast enough to be a page: parsing every line of a wide window to discard almost all of it is the whole cost of the query. Measured at 12,000 decisions across three day files, the summary is ~65 ms and a search ~40 ms.
+
+  **The search term is a substring test and never a `RegExp`.** User input compiled into a pattern is a ReDoS vector, and none of these lookups need patterns; a test asserts `new RegExp` does not appear in the service.
+
+  **Read-only by absence.** The module registers `GET` routes and nothing else — the same enforcement style as the missing KashFlow wrappers in hcs-sync and the read-only content API in the website module. It is not that writes are disabled; there is no route to receive one, which is also why nothing here needs CSRF. A test fails if any other verb appears in `mailRoutes.js`, and the views are asserted to contain no `POST` form.
+
+  **Admin only, which is narrower than the finance department pattern used by `/bank`,** because the subject category here is anyone who writes to the business. Widening it is one entry in `rolePermissionsConfig.routeAccess` plus the route guard, and should be a decision rather than a drift; a test pins the entry to exactly `['admin']`.
+
+  **Sender-controlled values are escaped and asserted to be.** The sender chooses their own address and HELO string, so these records are attacker-influenced in a way most of this app's data is not.
+
+### Changed
+- **The Article 30 register records the mail filtering log (`ropaConfig` A8).** Its subject category is `any_inbound_correspondent` — wider than any other activity in the register, and the fact worth writing down: this is the one place the platform holds data about people it has no relationship with. Lawful basis is legitimate interests, retention is the 90-day host deletion job, and the cross-border position is recorded honestly as unassessed, since the filtering cluster's region is unconfirmed and the syslog transport it offers has no TLS option — which is why the template carries no message content and no subject lines. The filtering provider is listed as a processor. A test fails if the activity or the processor entry goes missing.
+
+### Deployment
+- **Needs a read-only bind mount; without it the page says so rather than breaking.** `docker-compose.yml` mounts `/mnt/data/mailsiem/events` (override with `MAILSIEM_HOST_DIR`) at `/app/mailsiem/events:ro`, and `MAILSIEM_EVENTS_DIR` overrides the path the app reads. The mount must stay read-only: hcs-app is a reader, and the host's retention job is what makes the 90-day policy true. Unmounted — which is the state this ships in, since the image deploys before the stack change — `/mail` renders a "collector not mounted" banner, which is deliberately a different message from an empty log.
+- No schema change: `requiredSchemasVersion` stays 3.0.0, so the three-step `hcs-schemas` deploy does not apply to this release.
+
 ## [6.31.0] - 2026-08-21
 
 ### Security

--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ import __gdprRoutes from './mongoose/routes/gdprRoutes.js';
 import __legalRoutes from './mongoose/routes/legalRoutes.js';
 import __companyDocsRoutes from './mongoose/routes/companyDocsRoutes.js';
 import __auditRoutes from './mongoose/routes/auditRoutes.js';
+import __mailRoutes from './mongoose/routes/mailRoutes.js';
 import __webRoutes from './mongoose/routes/webRoutes.js';
 import __webApiRoutes from './mongoose/routes/webApiRoutes.js';
 import __errorHandlerService from './services/errorHandlerService.js';
@@ -581,6 +582,9 @@ const main = async () => {
     appRouter.use('/', __legalRoutes);
     appRouter.use('/', __companyDocsRoutes);
     appRouter.use('/', __auditRoutes);
+    // Inbound mail filtering log. Reads NDJSON from the mailsiem collector's
+    // read-only bind mount; no database, and no write path anywhere in it.
+    appRouter.use('/', __mailRoutes);
     appRouter.use('/', __webRoutes);
     // Read-only content API for hcs-web. Inside appRouter so it gets body
     // parsing, request logging and maintenance's JSON 503; exempted from the

--- a/compose.env.example
+++ b/compose.env.example
@@ -419,3 +419,26 @@ WEB_API_TOKEN=
 # just takes until the next poll rather than a second or two.
 WEB_REVALIDATE_URL=https://heroncs.co.uk/revalidate
 WEB_REVALIDATE_SECRET=
+
+########################################
+# Inbound mail filtering log (mailsiem)
+########################################
+# used by: `mongoose/services/mailFilterLogService.js` (the /mail page) # optional
+#
+# Where the mailsiem collector's NDJSON day files are mounted, read-only. The
+# collector is a separate service on the host: it receives a syslog line per
+# filtering decision from the SpamExperts cluster and writes one file per day.
+#
+# This is a path inside the container, and the mount is what supplies it:
+#
+#   volumes:
+#     - /mnt/data/mailsiem/events:/app/mailsiem/events:ro
+#
+# The mount must stay read-only. hcs-app is a reader; the collector owns these
+# files and a host cron job deletes them at 90 days, which is the only thing
+# making that retention true. Do not ingest them into Mongo — Mongo is dumped
+# nightly with its own 90-day archive retention, so copies would outlive the
+# policy by up to another 90 days.
+#
+# Unset or unmounted, /mail renders and says the collector is not mounted.
+MAILSIEM_EVENTS_DIR=/app/mailsiem/events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,12 @@ services:
     volumes:
       - ./uploads:/uploads
       - ./logs:/logs
+      # Inbound mail filtering decisions, written by the mailsiem collector on
+      # the host. READ-ONLY on purpose: the collector owns these files and a
+      # host cron job deletes them at 90 days, which is the only thing that
+      # makes that retention true. hcs-app is a reader and nothing more.
+      # Absent, /mail renders and says the collector is not mounted.
+      - ${MAILSIEM_HOST_DIR:-/mnt/data/mailsiem/events}:/app/mailsiem/events:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:${PORT}/healthz || exit 1"]
       interval: 10s

--- a/mongoose/config/dashboardTilesConfig.js
+++ b/mongoose/config/dashboardTilesConfig.js
@@ -231,6 +231,14 @@ export default {
         department: ['finance'],
         buttonClass: 'bg-amber-600 hover:bg-amber-700'
     },
+    // ── Inbound mail ──────────────────────────────────────────────────
+    MailFilteringLog: {
+        title: 'Mail Filtering Log',
+        description: 'Why inbound mail was delivered or stopped. Search by sender or recipient to answer "did my email reach you?".',
+        link: '/mail',
+        department: ['admin'],
+        buttonClass: 'bg-green-700 hover:bg-green-800'
+    },
     /*
     KF_Customers: {
         title: 'KF Customers',

--- a/mongoose/config/rolePermissionsConfig.js
+++ b/mongoose/config/rolePermissionsConfig.js
@@ -182,6 +182,15 @@ const routeAccess = {
   // are enforced by the adminGuard on those routes in bankRoutes.js.
   '/bank':                ['admin', 'accountant'],
 
+  // Inbound mail filtering log. Same longest-prefix rule as '/bank': the one
+  // '/mail' entry covers the whole module.
+  //
+  // Admin only, and narrower than the finance department on purpose: every
+  // record names a sender and a recipient, including people who appear nowhere
+  // else in this system and never chose to deal with us. Widening it is a
+  // decision about third-party personal data, not a convenience.
+  '/mail':                ['admin'],
+
   // Website content editor. Same longest-prefix rule as '/bank': one entry
   // covers the whole module.
   //

--- a/mongoose/config/ropaConfig.js
+++ b/mongoose/config/ropaConfig.js
@@ -7,8 +7,8 @@
  * beyond the normal deployment cycle.
  */
 const ropa = {
-  version: '2026-08-03',
-  lastUpdated: '2026-08-03',
+  version: '2026-08-21',
+  lastUpdated: '2026-08-21',
   controller: {
     name: 'Heron Constructive Solutions LTD',
     system: 'hcs-app',
@@ -111,6 +111,39 @@ const ropa = {
       recipients: ['internal_finance'],
       crossBorderTransfer: 'None',
     },
+    {
+      id: 'A8',
+      name: 'Inbound mail filtering decisions',
+      purpose:
+        'Keep an independent record of how the upstream spam filter treated mail addressed to us, '
+        + 'so wrongly rejected correspondence can be identified and answered for without relying on '
+        + "the provider's own support process",
+      // Legitimate interests, not consent: the senders are third parties who
+      // never had a relationship with us to consent through, and the interest
+      // being served is knowing whether our own mail service is losing genuine
+      // correspondence. Mail security is named in Recital 49 as a legitimate
+      // interest in its own right.
+      lawfulBasis: ['legitimate_interests'],
+      // Every record names a sender and a recipient. Subject lines and the
+      // other free-text headers are deliberately excluded from the syslog
+      // template, so no message content is held.
+      dataCategories: ['contact', 'communications metadata', 'network identifiers'],
+      // Wider than any other activity in this register: it covers anyone who
+      // emails the business, including people who appear nowhere else in the
+      // system and never chose to deal with us.
+      subjectCategories: ['any_inbound_correspondent', 'employees', 'suppliers', 'customers'],
+      // Not a database. NDJSON files written by the mailsiem collector on the
+      // host and read through a read-only mount; hcs-app never copies them into
+      // Mongo, which is what keeps the deletion job below the single thing that
+      // makes the retention true. See mailFilterLogService.js.
+      systems: ['mailsiem.events (host NDJSON, read-only mount)'],
+      retention: '90 days, enforced by a scheduled deletion job on the collector host',
+      recipients: ['internal_admins'],
+      // The filtering cluster is operated by the mail provider; its egress
+      // region has not been confirmed, and the syslog transport it offers has
+      // no TLS option. That is why the template carries no message content.
+      crossBorderTransfer: 'Not assessed — filtering cluster region unconfirmed',
+    },
   ],
 
   processors: [
@@ -135,6 +168,12 @@ const ropa = {
     {
       name: 'Paperless-ngx host',
       service: 'document_processing',
+      dpaStatus: 'pending_evidence',
+      transferAssessment: 'pending',
+    },
+    {
+      name: 'SpamExperts / StrikeMail (via mail provider)',
+      service: 'inbound_mail_filtering',
       dpaStatus: 'pending_evidence',
       transferAssessment: 'pending',
     },

--- a/mongoose/controllers/mailFilterController.js
+++ b/mongoose/controllers/mailFilterController.js
@@ -1,0 +1,70 @@
+import path from 'path';
+import log from '../services/mailFilterLogService.js';
+
+/**
+ * HTTP layer for the inbound mail filtering log. Thin by design: parse and
+ * clamp the query string, delegate to mailFilterLogService, render.
+ *
+ * Auth lives in mailRoutes.js, not here.
+ *
+ * There is no database call anywhere in this file and no mdb.connect(): the
+ * data is NDJSON on a read-only bind mount, owned by the mailsiem collector on
+ * the host. See mailFilterLogService.js for why it is not in Mongo.
+ *
+ * Every handler is a GET. There is no write path in this module — not a
+ * disabled one, an absent one.
+ */
+
+const VIEW = (name) => path.join('tailwindcss', 'mail', name);
+
+export const getIndex = async (req, res, next) => {
+  try {
+    const q = log.normaliseQuery(req.query.q);
+    const days = log.normaliseDays(req.query.days);
+    const blockedOnly = req.query.blocked === '1';
+
+    // The summary is rendered on every load, so it uses its own narrower
+    // window and is not widened by the search's `days`. Searching 90 days is a
+    // deliberate act; recomputing 90 days of counters on every page view is not.
+    const summary = await log.summary({});
+
+    // A bare page load must not scan anything: with no search term and no
+    // filter there is nothing to narrow by, and returning "the most recent
+    // hundred" would invite reading it as a complete list.
+    const results = (q || blockedOnly)
+      ? await log.search({ q, days, blockedOnly, limit: 200 })
+      : null;
+
+    res.render(VIEW('index'), {
+      title: 'Mail Filtering Log',
+      status: log.status(),
+      summary,
+      results,
+      q,
+      days,
+      blockedOnly,
+      maxDays: log.MAX_DAYS,
+    });
+  } catch (err) { next(err); }
+};
+
+/**
+ * Everything recorded against one filtering id. A message with several
+ * recipients is several decisions sharing that id, so this page is the only
+ * place the fan-out is visible as one thing.
+ */
+export const getMessage = async (req, res, next) => {
+  try {
+    const id = log.normaliseQuery(req.params.id);
+    const found = await log.byId(id);
+    res.render(VIEW('message'), {
+      title: `Message ${id}`,
+      id,
+      status: log.status(),
+      rows: found.rows,
+      mounted: found.mounted,
+    });
+  } catch (err) { next(err); }
+};
+
+export default { getIndex, getMessage };

--- a/mongoose/routes/mailRoutes.js
+++ b/mongoose/routes/mailRoutes.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import authService from '../../services/authService.js';
+import ctrl from '../controllers/mailFilterController.js';
+
+const router = express.Router();
+
+/**
+ * Inbound mail filtering log.
+ *
+ * Admin only. These records are third-party personal data — every line names a
+ * sender and a recipient, including people who appear nowhere else in this
+ * system and never chose to deal with us. That is a narrower audience than the
+ * finance department pattern used by /bank, and deliberately so; widening it is
+ * one entry in rolePermissionsConfig.routeAccess plus the guard below, and
+ * should be a decision rather than a drift.
+ *
+ * '/mail' is also listed in rolePermissionsConfig.routeAccess, which the global
+ * ensureRouteAccess middleware enforces; the guard here is the second layer.
+ * matchRoutePattern does literal longest-prefix matching with no :param
+ * support, so the one '/mail' entry covers the whole module.
+ *
+ * GET only, and that is the enforcement mechanism rather than a convention:
+ * this module cannot alter a filtering decision because it has no route that
+ * writes one. Nothing here needs CSRF because nothing here mutates; a POST
+ * appearing in this file means that reasoning has to be revisited, and
+ * tests/mailRoutesGuards.test.js fails if one does.
+ */
+const mailGuard = [
+  authService.ensureAuthenticated,
+  authService.ensureRole('admin'),
+];
+
+router.get('/mail', ...mailGuard, ctrl.getIndex);
+router.get('/mail/message/:id', ...mailGuard, ctrl.getMessage);
+
+export default router;

--- a/mongoose/services/mailFilterLogService.js
+++ b/mongoose/services/mailFilterLogService.js
@@ -1,0 +1,302 @@
+/**
+ * Inbound mail filtering decisions, read from the mailsiem collector.
+ *
+ * Context: inbound mail to heroncs.co.uk was being silently rejected by the
+ * SpamExperts/StrikeMail filter (Quarantine response set to Rejected, so
+ * legitimate senders got a 550 and we never saw it). The mailsiem collector on
+ * the host receives a syslog line per filtering decision and writes one NDJSON
+ * file per day. This service is hcs-app's read-only window onto those files, so
+ * "did my email reach you?" is answerable from the platform rather than from a
+ * support ticket.
+ *
+ * WHY FILES AND NOT MONGO — do not "improve" this by ingesting into a
+ * collection. These records are third-party personal data (who emails this
+ * business, and who they email) held under a 90-day retention rule enforced by
+ * a deletion job on the host. Mongo is dumped nightly by mongo-backup.sh with
+ * its own 90-day archive retention, and those archives are browsable at
+ * files.heroncs.co.uk — so ingesting would leave copies alive for up to ~180
+ * days against a 90-day policy, and the retention job could no longer be the
+ * single thing that makes the policy true. Reading the files keeps the
+ * collector the sole owner of the data: when a day file is deleted, it is gone
+ * everywhere, including here.
+ *
+ * Consequences of that choice, all deliberate:
+ *  - There is no index. Every query is a bounded scan, so the window is capped
+ *    (MAX_DAYS) and every entry point takes an explicit day count.
+ *  - Lines are filtered as raw text BEFORE JSON.parse. Parsing every line of a
+ *    90-day window to discard almost all of it is the whole cost of the query;
+ *    a substring test on the raw line is roughly free by comparison.
+ *  - Nothing here writes, and there is no write path to add one to. The module
+ *    is read-only by absence, the same enforcement style as the missing
+ *    KashFlow wrappers in hcs-sync.
+ *
+ * The directory is a read-only bind mount supplied by docker-compose. If it is
+ * absent — which it will be until the collector is deployed alongside the app —
+ * every function here degrades to an empty, explicitly "not mounted" result
+ * rather than throwing, so the page renders and says so.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+
+/** Matches the collector's 90-day retention: older files do not exist. */
+export const MAX_DAYS = 90;
+export const DEFAULT_SEARCH_DAYS = 30;
+/** Summary is rendered on every page load, so its default window is narrower. */
+export const DEFAULT_SUMMARY_DAYS = 7;
+export const MAX_LIMIT = 500;
+export const MAX_QUERY_LENGTH = 200;
+
+/**
+ * A scan can never run unbounded: a corrupt or unexpectedly enormous day file
+ * would otherwise hold a request open indefinitely. On hitting this the result
+ * is flagged truncated rather than silently short.
+ */
+const MAX_LINES_PER_REQUEST = 2_000_000;
+
+const FILE_RE = /^(\d{4}-\d{2}-\d{2})\.ndjson$/;
+
+/** Read at call time, not import time, so tests and compose can both set it. */
+export function eventsDir() {
+  return process.env.MAILSIEM_EVENTS_DIR || '/app/mailsiem/events';
+}
+
+/**
+ * A decision that stopped the mail. SpamExperts uses several words for it
+ * depending on product and template, and the exact vocabulary is not pinned
+ * until the cluster is live, so this matches the family rather than a list of
+ * literals. Kept in one place because the summary counters and the
+ * "blocked only" filter must agree.
+ */
+export function isBlocked(status) {
+  return /reject|block|quarantin|defer|discard/i.test(String(status || ''));
+}
+
+function clampInt(value, fallback, min, max) {
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+export function normaliseDays(value, fallback = DEFAULT_SEARCH_DAYS) {
+  return clampInt(value, fallback, 1, MAX_DAYS);
+}
+
+export function normaliseQuery(value) {
+  return String(value || '').trim().slice(0, MAX_QUERY_LENGTH);
+}
+
+/**
+ * The day files covering the last `days` days, newest first. Derived from the
+ * requested dates rather than by listing the directory, so a narrow window
+ * never pays for a wide one; files that do not exist (quiet days, or days
+ * already retired by the retention job) are simply skipped.
+ */
+export function dayFiles(days, now = new Date()) {
+  const dir = eventsDir();
+  const out = [];
+  for (let i = 0; i < days; i += 1) {
+    const d = new Date(now.getTime() - i * 86400000);
+    const date = d.toISOString().slice(0, 10);
+    const file = path.join(dir, `${date}.ndjson`);
+    if (fs.existsSync(file)) out.push({ date, file });
+  }
+  return out;
+}
+
+/**
+ * Whether the collector's output is actually mounted, and what it holds.
+ * Rendered as a banner: an empty result means something very different when
+ * the mount is missing than when the filter simply had a quiet week.
+ */
+export function status() {
+  const dir = eventsDir();
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return { mounted: false, dir, files: 0, bytes: 0, oldest: null, newest: null };
+  }
+  const dates = entries
+    .map((name) => FILE_RE.exec(name))
+    .filter(Boolean)
+    .map((m) => m[1])
+    .sort();
+  let bytes = 0;
+  for (const date of dates) {
+    try {
+      bytes += fs.statSync(path.join(dir, `${date}.ndjson`)).size;
+    } catch {
+      // A file retired by the retention job between readdir and stat is normal.
+    }
+  }
+  return {
+    mounted: true,
+    dir,
+    files: dates.length,
+    bytes,
+    oldest: dates[0] || null,
+    newest: dates[dates.length - 1] || null,
+  };
+}
+
+/**
+ * Stream one day file, handing each line that survives the raw-text filter to
+ * `onRow` as a parsed object. Returns the number of lines read.
+ *
+ * `onRow` returning false stops the scan for that file — that is how the result
+ * limit avoids reading the remainder of a large day.
+ */
+async function scanFile(file, rawFilter, onRow) {
+  let stream;
+  try {
+    stream = fs.createReadStream(file, { encoding: 'utf8' });
+  } catch {
+    return 0;
+  }
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let lines = 0;
+  try {
+    for await (const line of rl) {
+      if (!line) continue;
+      lines += 1;
+      if (rawFilter && !rawFilter(line)) continue;
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch {
+        // A torn final line (the collector was mid-write) is not an error worth
+        // failing a page over; the collector's own health job watches for real
+        // parse trouble.
+        continue;
+      }
+      if (onRow(row) === false) break;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return lines;
+}
+
+/**
+ * Find filtering decisions. `q` is matched as a case-insensitive substring of
+ * the whole raw JSON line, so one box searches sender, recipient, sending IP,
+ * message-id and the filtering id alike — the same behaviour as the
+ * mailsiem-query.sh CLI on the host, deliberately.
+ *
+ * It is a substring test and never a RegExp: user input compiled into a pattern
+ * is a ReDoS waiting to happen, and none of these lookups need patterns.
+ */
+export async function search({ q = '', days = DEFAULT_SEARCH_DAYS, blockedOnly = false, limit = 100 } = {}) {
+  const needle = normaliseQuery(q).toLowerCase();
+  const window = normaliseDays(days);
+  const cap = clampInt(limit, 100, 1, MAX_LIMIT);
+  const st = status();
+
+  if (!st.mounted) {
+    return { rows: [], mounted: false, truncated: false, scanned: 0, filesScanned: 0, days: window };
+  }
+
+  const rows = [];
+  let scanned = 0;
+  let truncated = false;
+  let filesScanned = 0;
+
+  const rawFilter = needle ? (line) => line.toLowerCase().includes(needle) : null;
+
+  for (const { file } of dayFiles(window)) {
+    if (truncated) break;
+    filesScanned += 1;
+    // eslint-disable-next-line no-await-in-loop
+    scanned += await scanFile(file, rawFilter, (row) => {
+      if (blockedOnly && !isBlocked(row.status)) return true;
+      rows.push(row);
+      if (rows.length >= cap) {
+        truncated = true;
+        return false;
+      }
+      return true;
+    });
+    if (scanned >= MAX_LINES_PER_REQUEST) truncated = true;
+  }
+
+  // Newest first. event_time is the filter's own clock; received_at is ours and
+  // is always present, so it is the fallback rather than the primary.
+  rows.sort((a, b) => String(b.event_time || b.received_at || '').localeCompare(String(a.event_time || a.received_at || '')));
+
+  return { rows, mounted: true, truncated, scanned, filesScanned, days: window };
+}
+
+/**
+ * Headline counters for the landing page: how much mail was stopped, and what
+ * the filter said its reason was.
+ *
+ * `extra_class` is the field that explains a classification, which makes it the
+ * most valuable column here — a run of identical reasons across many senders is
+ * what a misconfigured quarantine response looks like from the outside, and is
+ * exactly the fault this whole pipeline exists to surface.
+ */
+export async function summary({ days = DEFAULT_SUMMARY_DAYS } = {}) {
+  const window = normaliseDays(days, DEFAULT_SUMMARY_DAYS);
+  const st = status();
+  if (!st.mounted) {
+    return { mounted: false, days: window, total: 0, blocked: 0, reasons: [], byDay: [], truncatedFields: 0 };
+  }
+
+  let total = 0;
+  let blocked = 0;
+  let truncatedFields = 0;
+  const reasons = new Map();
+  const byDay = new Map();
+  let scanned = 0;
+
+  for (const { date, file } of dayFiles(window)) {
+    if (scanned >= MAX_LINES_PER_REQUEST) break;
+    byDay.set(date, { date, total: 0, blocked: 0 });
+    // eslint-disable-next-line no-await-in-loop
+    scanned += await scanFile(file, null, (row) => {
+      total += 1;
+      const day = byDay.get(date);
+      day.total += 1;
+      // kv_partial marks a value that contained a comma and was truncated by
+      // the collector's parser. Surfaced rather than hidden: it means the
+      // template's shape changed and the parser needs quoting support.
+      if (row.kv_partial) truncatedFields += 1;
+      if (isBlocked(row.status)) {
+        blocked += 1;
+        day.blocked += 1;
+        const reason = String(row.extra_class || '').trim() || '(no reason given)';
+        reasons.set(reason, (reasons.get(reason) || 0) + 1);
+      }
+      return true;
+    });
+  }
+
+  return {
+    mounted: true,
+    days: window,
+    total,
+    blocked,
+    truncatedFields,
+    reasons: [...reasons.entries()]
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10),
+    byDay: [...byDay.values()].sort((a, b) => a.date.localeCompare(b.date)),
+  };
+}
+
+/**
+ * Every decision recorded against one filtering id. A message to several
+ * recipients produces one decision per recipient — the collector's dedupe key
+ * is id + filtering_host + recipient — so this is a list, not a single record.
+ */
+export async function byId(id, { days = MAX_DAYS } = {}) {
+  const wanted = normaliseQuery(id);
+  if (!wanted) return { rows: [], mounted: status().mounted, days: normaliseDays(days) };
+  const found = await search({ q: wanted, days, limit: MAX_LIMIT });
+  return { ...found, rows: found.rows.filter((r) => String(r.id) === wanted) };
+}
+
+export default { eventsDir, status, search, summary, byId, isBlocked, dayFiles, normaliseDays, normaliseQuery, MAX_DAYS, DEFAULT_SEARCH_DAYS, DEFAULT_SUMMARY_DAYS, MAX_LIMIT };

--- a/mongoose/views/tailwindcss/mail/index.ejs
+++ b/mongoose/views/tailwindcss/mail/index.ejs
@@ -1,0 +1,214 @@
+<%
+  // Formatting helpers, kept local: this module has no Mongo documents and so
+  // none of the model-shaped view helpers apply to it.
+  const fmtTime = (r) => String(r.event_time || r.received_at || '').replace('T', ' ').slice(0, 19) || '—';
+  const fmtBytes = (n) => {
+    if (!n) return '0 B';
+    const u = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.min(Math.floor(Math.log(n) / Math.log(1024)), u.length - 1);
+    return `${(n / (1024 ** i)).toFixed(i ? 1 : 0)} ${u[i]}`;
+  };
+  const blocked = (s) => /reject|block|quarantin|defer|discard/i.test(String(s || ''));
+%>
+<div class="max-w-7xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+
+  <div class="flex items-center gap-3 mb-6">
+    <h1 class="text-xl font-bold">Mail Filtering Log</h1>
+    <span class="text-xs px-2 py-0.5 rounded-full border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400">
+      Read only
+    </span>
+  </div>
+
+  <p class="text-sm text-gray-700 dark:text-gray-300 mb-6 max-w-3xl">
+    Every filtering decision the SpamExperts cluster has made about mail addressed to us.
+    Search by sender, recipient, sending IP, message-id or filtering id to find out what
+    happened to a specific message.
+  </p>
+
+  <% if (!status.mounted) { %>
+    <!-- The collector is a separate service on the host. Until its output is
+         mounted this page has nothing to read, which is a different thing from
+         a quiet week and has to read as such. -->
+    <div class="mb-6 p-4 rounded-2xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">
+      <h2 class="font-semibold text-sm text-amber-800 dark:text-amber-300 mb-1">Collector not mounted</h2>
+      <p class="text-sm text-amber-800 dark:text-amber-300">
+        No filtering log is available to this container. The mailsiem collector writes to
+        <span class="font-mono text-xs"><%= status.dir %></span>, which is not present —
+        the stack needs the read-only bind mount adding, or the collector is not running.
+      </p>
+    </div>
+  <% } else { %>
+
+    <!-- Headline counters -->
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+      <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-4">
+        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Decisions, last <%= summary.days %> days</div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-white"><%= summary.total.toLocaleString('en-GB') %></div>
+      </div>
+      <div class="bg-white dark:bg-gray-900 border <%= summary.blocked ? 'border-red-300 dark:border-red-700' : 'border-gray-200 dark:border-gray-700' %> rounded-2xl shadow-sm p-4">
+        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Stopped before delivery</div>
+        <div class="text-2xl font-bold <%= summary.blocked ? 'text-red-700 dark:text-red-400' : 'text-gray-900 dark:text-white' %>">
+          <%= summary.blocked.toLocaleString('en-GB') %>
+        </div>
+      </div>
+      <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-4">
+        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Log held</div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-white"><%= status.files %> <span class="text-sm font-normal text-gray-500">days</span></div>
+        <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          <%= status.oldest || '—' %> → <%= status.newest || '—' %> &middot; <%= fmtBytes(status.bytes) %>
+        </div>
+      </div>
+    </div>
+
+    <% if (summary.truncatedFields) { %>
+      <!-- kv_partial: the collector's parser found a comma inside a field value.
+           The template is supposed to make that impossible, so it means the
+           template changed and the parser needs quoting support. -->
+      <div class="mb-6 p-4 rounded-2xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">
+        <p class="text-sm text-amber-800 dark:text-amber-300">
+          <strong><%= summary.truncatedFields %></strong> decision(s) in this window had a field value
+          containing a comma, so that value is truncated below. The syslog template is supposed to make
+          this impossible — it has probably changed, and the collector's parser needs quoting support.
+        </p>
+      </div>
+    <% } %>
+
+    <!-- Why mail was stopped. This is the reason the module exists: a run of
+         identical reasons across unrelated senders is what a misconfigured
+         quarantine response looks like from the outside. -->
+    <div class="mb-8">
+      <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        Why mail was stopped &mdash; last <%= summary.days %> days
+      </h2>
+      <% if (!summary.reasons.length) { %>
+        <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
+          Nothing was stopped in this window.
+        </div>
+      <% } else { %>
+        <div class="overflow-hidden border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+            <thead class="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Reason given by the filter</th>
+                <th class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Messages</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
+              <% summary.reasons.forEach(r => { %>
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-800 transition">
+                  <td class="px-4 py-3 text-gray-900 dark:text-white"><%= r.reason %></td>
+                  <td class="px-4 py-3 text-right font-mono text-xs text-gray-700 dark:text-gray-300"><%= r.count.toLocaleString('en-GB') %></td>
+                </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+      <% } %>
+    </div>
+
+    <!-- Search -->
+    <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+      Find a message
+    </h2>
+    <form method="GET" action="/mail" class="flex gap-2 flex-wrap mb-6">
+      <input name="q" value="<%= q %>" placeholder="Sender, recipient, IP, message-id or filtering id&hellip;"
+        class="flex-1 min-w-0 text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+               bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+               focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent" />
+      <select name="days"
+        class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+               bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+               focus:outline-none focus:ring-2 focus:ring-green-500">
+        <% [1, 7, 30, 90].filter(d => d <= maxDays).forEach(d => { %>
+          <option value="<%= d %>" <%= days === d ? 'selected' : '' %>>Last <%= d %> day<%= d === 1 ? '' : 's' %></option>
+        <% }) %>
+      </select>
+      <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 px-2">
+        <input type="checkbox" name="blocked" value="1" <%= blockedOnly ? 'checked' : '' %>
+          class="rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500" />
+        Stopped only
+      </label>
+      <button type="submit"
+        class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
+        Search
+      </button>
+    </form>
+
+    <% if (results === null) { %>
+      <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
+        Enter a search term above, or tick &ldquo;stopped only&rdquo;, to list decisions.
+      </div>
+    <% } else if (!results.rows.length) { %>
+      <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
+        No filtering decisions matched in the last <%= results.days %> days.
+        <% if (status.oldest) { %>
+          <div class="mt-1 text-xs">The log starts at <%= status.oldest %>; anything older has passed the 90-day retention limit.</div>
+        <% } %>
+      </div>
+    <% } else { %>
+      <% if (results.truncated) { %>
+        <div class="mb-3 p-3 rounded-xl border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 text-sm text-blue-800 dark:text-blue-300">
+          Showing the first <%= results.rows.length %> matches only. Narrow the search or the window to see the rest.
+        </div>
+      <% } %>
+      <div class="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Time</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Outcome</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">From</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">To</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Why</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
+            <% results.rows.forEach(r => { %>
+              <tr class="hover:bg-gray-50 dark:hover:bg-gray-800 transition">
+                <td class="px-4 py-3 whitespace-nowrap font-mono text-xs text-gray-700 dark:text-gray-300"><%= fmtTime(r) %></td>
+                <td class="px-4 py-3 whitespace-nowrap">
+                  <span class="text-xs px-2 py-0.5 rounded-full <%= blocked(r.status)
+                    ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+                    : 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400' %>">
+                    <%= r.status || 'unknown' %>
+                  </span>
+                  <% if (r.main_class) { %>
+                    <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      <%= [r.main_class, r.sub_class].filter(Boolean).join(' / ') %>
+                    </div>
+                  <% } %>
+                </td>
+                <td class="px-4 py-3 text-gray-900 dark:text-white">
+                  <%= r.sender || '—' %>
+                  <% if (r.sender_ip) { %>
+                    <div class="font-mono text-xs text-gray-500 dark:text-gray-400"><%= r.sender_ip %></div>
+                  <% } %>
+                </td>
+                <td class="px-4 py-3 text-gray-900 dark:text-white"><%= r.recipient || '—' %></td>
+                <td class="px-4 py-3 text-gray-700 dark:text-gray-300">
+                  <%= r.extra_class || '—' %>
+                  <% if (r.kv_partial) { %>
+                    <span class="text-xs text-amber-700 dark:text-amber-400" title="A comma in this value truncated it">[truncated]</span>
+                  <% } %>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap">
+                  <% if (r.id) { %>
+                    <a href="/mail/message/<%= encodeURIComponent(r.id) %>"
+                      class="text-xs px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 hover:bg-green-600 hover:text-white transition">
+                      Open
+                    </a>
+                  <% } %>
+                </td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      </div>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-3">
+        <%= results.rows.length.toLocaleString('en-GB') %> decision(s) from
+        <%= results.filesScanned %> day file(s).
+      </p>
+    <% } %>
+  <% } %>
+</div>

--- a/mongoose/views/tailwindcss/mail/message.ejs
+++ b/mongoose/views/tailwindcss/mail/message.ejs
@@ -1,0 +1,102 @@
+<%
+  const fmtTime = (r) => String(r.event_time || r.received_at || '').replace('T', ' ').slice(0, 19) || '—';
+  const blocked = (s) => /reject|block|quarantin|defer|discard/i.test(String(s || ''));
+  // Fields shown in the detail block, in the order the syslog template emits
+  // them. Anything the template gains later still reaches the raw line below,
+  // so a new field is never invisible — just not yet given a label.
+  const DETAIL = [
+    ['filtering_host', 'Filtering host'],
+    ['sender_host', 'Sender host'],
+    ['helo', 'HELO'],
+    ['sender_ip', 'Sender IP'],
+    ['sender_location', 'Sender location'],
+    ['domain', 'Domain'],
+    ['message_id_header', 'Message-ID'],
+    ['incoming_size', 'Size (bytes)'],
+    ['forwarded', 'Forwarded'],
+    ['main_class', 'Main class'],
+    ['sub_class', 'Sub class'],
+    ['extra_class', 'Reason'],
+    ['product', 'Product'],
+    ['received_at', 'Recorded at'],
+  ];
+%>
+<div class="max-w-7xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+
+  <div class="flex items-center gap-3 mb-6">
+    <a href="/mail" class="text-sm text-green-700 dark:text-green-400 hover:underline">&larr; Mail filtering log</a>
+    <span class="text-gray-400">/</span>
+    <h1 class="text-xl font-bold font-mono"><%= id %></h1>
+  </div>
+
+  <% if (!mounted) { %>
+    <div class="p-4 rounded-2xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">
+      <p class="text-sm text-amber-800 dark:text-amber-300">The filtering log is not available to this container.</p>
+    </div>
+  <% } else if (!rows.length) { %>
+    <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
+      No decision with this filtering id is in the log.
+      <div class="mt-1 text-xs">It may have passed the 90-day retention limit<%= status.oldest ? ` — the log starts at ${status.oldest}` : '' %>.</div>
+    </div>
+  <% } else { %>
+
+    <p class="text-sm text-gray-700 dark:text-gray-300 mb-6 max-w-3xl">
+      <% if (rows.length > 1) { %>
+        This message was addressed to <strong><%= rows.length %></strong> recipients, and the filter
+        recorded a decision for each one. They can differ: a message can be delivered to one
+        recipient and stopped for another.
+      <% } else { %>
+        One filtering decision was recorded for this message.
+      <% } %>
+    </p>
+
+    <% rows.forEach(r => { %>
+      <div class="mb-6 bg-white dark:bg-gray-900 border <%= blocked(r.status)
+        ? 'border-red-300 dark:border-red-700' : 'border-green-300 dark:border-green-700' %> rounded-2xl shadow-sm p-4">
+
+        <div class="flex items-start justify-between gap-4 mb-4 flex-wrap">
+          <div>
+            <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Recipient</div>
+            <div class="text-lg font-bold text-gray-900 dark:text-white"><%= r.recipient || '—' %></div>
+            <div class="text-sm text-gray-700 dark:text-gray-300 mt-1">from <%= r.sender || 'unknown sender' %></div>
+          </div>
+          <div class="text-right">
+            <span class="text-xs px-2 py-0.5 rounded-full <%= blocked(r.status)
+              ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+              : 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400' %>">
+              <%= r.status || 'unknown' %>
+            </span>
+            <div class="font-mono text-xs text-gray-500 dark:text-gray-400 mt-1"><%= fmtTime(r) %></div>
+          </div>
+        </div>
+
+        <% if (r.kv_partial) { %>
+          <div class="mb-4 p-3 rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-sm text-amber-800 dark:text-amber-300">
+            A field value contained a comma and was truncated by the collector's parser.
+            The complete original line is shown at the bottom of this card.
+          </div>
+        <% } %>
+
+        <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+          <% DETAIL.forEach(([key, label]) => { %>
+            <% if (r[key] !== undefined && r[key] !== null && r[key] !== '') { %>
+              <div class="flex gap-2 text-sm">
+                <dt class="font-medium text-gray-500 dark:text-gray-400 min-w-[8rem]"><%= label %></dt>
+                <dd class="text-gray-900 dark:text-white break-all"><%= r[key] %></dd>
+              </div>
+            <% } %>
+          <% }) %>
+        </dl>
+
+        <% if (r.raw) { %>
+          <!-- The collector keeps the original syslog line on every record, so a
+               parsing mistake is recoverable after the fact rather than lost. -->
+          <details class="mt-4">
+            <summary class="text-sm text-gray-500 dark:text-gray-400 cursor-pointer hover:underline">Original syslog line</summary>
+            <pre class="mt-2 p-3 rounded-xl bg-gray-50 dark:bg-gray-800 font-mono text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all"><%= r.raw %></pre>
+          </details>
+        <% } %>
+      </div>
+    <% }) %>
+  <% } %>
+</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.31.0",
+  "version": "6.32.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/tests/mailFilterLogService.test.js
+++ b/tests/mailFilterLogService.test.js
@@ -1,0 +1,229 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import log from '../mongoose/services/mailFilterLogService.js';
+
+/**
+ * The filtering log is flat NDJSON on a read-only mount, not a collection, so
+ * these tests drive the real reader against a real temporary directory. No
+ * database and no HTTP.
+ */
+
+let dir;
+const ORIGINAL = process.env.MAILSIEM_EVENTS_DIR;
+
+/** A day file `n` days before today, in the collector's naming scheme. */
+function writeDay(daysAgo, rows) {
+  const d = new Date(Date.now() - daysAgo * 86400000).toISOString().slice(0, 10);
+  fs.writeFileSync(
+    path.join(dir, `${d}.ndjson`),
+    rows.map((r) => JSON.stringify(r)).join('\n') + '\n',
+  );
+  return d;
+}
+
+function decision(over = {}) {
+  return {
+    id: 'ID1',
+    filtering_host: 'mx1.eu.spamexperts.com',
+    event_time: new Date().toISOString(),
+    received_at: new Date().toISOString(),
+    sender: 'accounts@acme.co.uk',
+    recipient: 'invoices@heroncs.co.uk',
+    status: 'rejected',
+    main_class: 'Spam',
+    sub_class: 'Bulk',
+    extra_class: 'Quarantine response set to Rejected',
+    raw: 'ID1,mx1.eu.spamexperts.com,...',
+    ...over,
+  };
+}
+
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mailsiem-test-'));
+  process.env.MAILSIEM_EVENTS_DIR = dir;
+});
+
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  if (ORIGINAL === undefined) delete process.env.MAILSIEM_EVENTS_DIR;
+  else process.env.MAILSIEM_EVENTS_DIR = ORIGINAL;
+});
+
+beforeEach(() => {
+  for (const f of fs.readdirSync(dir)) fs.rmSync(path.join(dir, f), { force: true });
+});
+
+describe('mailFilterLogService — mount state', () => {
+  it('reports an unmounted directory instead of throwing', async () => {
+    process.env.MAILSIEM_EVENTS_DIR = path.join(dir, 'does-not-exist');
+    try {
+      const st = log.status();
+      assert.equal(st.mounted, false);
+      // The page must still render: an absent collector is a different message
+      // from a quiet week, but neither is an error.
+      const found = await log.search({ q: 'anything' });
+      assert.equal(found.mounted, false);
+      assert.deepEqual(found.rows, []);
+      const sum = await log.summary({});
+      assert.equal(sum.mounted, false);
+      assert.equal(sum.total, 0);
+    } finally {
+      process.env.MAILSIEM_EVENTS_DIR = dir;
+    }
+  });
+
+  it('reports the held window when files are present', () => {
+    writeDay(0, [decision()]);
+    writeDay(5, [decision({ id: 'ID2' })]);
+    const st = log.status();
+    assert.equal(st.mounted, true);
+    assert.equal(st.files, 2);
+    assert.ok(st.bytes > 0);
+    assert.ok(st.oldest < st.newest);
+  });
+
+  it('ignores files that are not day files', () => {
+    writeDay(0, [decision()]);
+    fs.writeFileSync(path.join(dir, 'mailsiem-retention.log'), 'not a day file\n');
+    fs.writeFileSync(path.join(dir, 'notadate.ndjson'), '{}\n');
+    assert.equal(log.status().files, 1);
+  });
+});
+
+describe('mailFilterLogService — search', () => {
+  it('matches any field, because it matches the raw line', async () => {
+    writeDay(0, [decision({ sender_ip: '203.0.113.45', message_id_header: '<abc@acme.co.uk>' })]);
+    for (const needle of ['accounts@acme.co.uk', 'invoices@heroncs.co.uk', '203.0.113.45', '<abc@acme.co.uk>', 'ID1']) {
+      const found = await log.search({ q: needle });
+      assert.equal(found.rows.length, 1, `expected a hit for ${needle}`);
+    }
+  });
+
+  it('is case-insensitive', async () => {
+    writeDay(0, [decision()]);
+    assert.equal((await log.search({ q: 'ACCOUNTS@ACME.CO.UK' })).rows.length, 1);
+  });
+
+  it('treats the query as a literal, never a pattern', async () => {
+    // A RegExp built from user input would match everything here and, worse,
+    // is a ReDoS vector. A substring test matches nothing, which is correct.
+    writeDay(0, [decision()]);
+    assert.equal((await log.search({ q: '.*' })).rows.length, 0);
+    assert.equal((await log.search({ q: '(a+)+$' })).rows.length, 0);
+  });
+
+  it('honours the day window rather than reading everything', async () => {
+    writeDay(0, [decision({ id: 'TODAY' })]);
+    writeDay(40, [decision({ id: 'OLD' })]);
+    const narrow = await log.search({ q: 'heroncs', days: 7 });
+    assert.deepEqual(narrow.rows.map((r) => r.id), ['TODAY']);
+    const wide = await log.search({ q: 'heroncs', days: 90 });
+    assert.equal(wide.rows.length, 2);
+  });
+
+  it('clamps the window to the collector retention period', () => {
+    assert.equal(log.normaliseDays(9999), log.MAX_DAYS);
+    assert.equal(log.normaliseDays(0), 1);
+    assert.equal(log.normaliseDays('nonsense'), log.DEFAULT_SEARCH_DAYS);
+  });
+
+  it('filters to stopped mail only', async () => {
+    writeDay(0, [
+      decision({ id: 'A', status: 'rejected' }),
+      decision({ id: 'B', status: 'accepted' }),
+      decision({ id: 'C', status: 'Quarantined' }),
+    ]);
+    const found = await log.search({ q: 'heroncs', blockedOnly: true });
+    assert.deepEqual(found.rows.map((r) => r.id).sort(), ['A', 'C']);
+  });
+
+  it('caps results and says so rather than returning a short list silently', async () => {
+    writeDay(0, Array.from({ length: 50 }, (_, i) => decision({ id: `ID${i}` })));
+    const found = await log.search({ q: 'heroncs', limit: 10 });
+    assert.equal(found.rows.length, 10);
+    assert.equal(found.truncated, true);
+  });
+
+  it('survives a torn final line without failing the request', async () => {
+    // The collector may be mid-write. One unreadable line must not cost the
+    // whole page.
+    const d = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(
+      path.join(dir, `${d}.ndjson`),
+      JSON.stringify(decision()) + '\n{"id":"TORN","recipient":"x@her',
+    );
+    const found = await log.search({ q: 'heroncs' });
+    assert.equal(found.rows.length, 1);
+  });
+
+  it('returns newest first', async () => {
+    writeDay(0, [decision({ id: 'NEW', event_time: '2026-08-21T10:00:00Z' })]);
+    writeDay(1, [decision({ id: 'OLD', event_time: '2026-08-20T10:00:00Z' })]);
+    const found = await log.search({ q: 'heroncs', days: 7 });
+    assert.deepEqual(found.rows.map((r) => r.id), ['NEW', 'OLD']);
+  });
+});
+
+describe('mailFilterLogService — summary', () => {
+  it('counts what was stopped and why', async () => {
+    writeDay(0, [
+      decision({ id: 'A', status: 'rejected', extra_class: 'Quarantine response set to Rejected' }),
+      decision({ id: 'B', status: 'rejected', extra_class: 'Quarantine response set to Rejected' }),
+      decision({ id: 'C', status: 'accepted', extra_class: '' }),
+    ]);
+    const sum = await log.summary({});
+    assert.equal(sum.total, 3);
+    assert.equal(sum.blocked, 2);
+    assert.deepEqual(sum.reasons[0], { reason: 'Quarantine response set to Rejected', count: 2 });
+  });
+
+  it('surfaces truncated fields, because they mean the template changed', async () => {
+    writeDay(0, [decision({ kv_partial: true }), decision({ id: 'B' })]);
+    assert.equal((await log.summary({})).truncatedFields, 1);
+  });
+
+  it('labels a stopped message with no stated reason rather than dropping it', async () => {
+    writeDay(0, [decision({ extra_class: '' })]);
+    const sum = await log.summary({});
+    assert.equal(sum.blocked, 1);
+    assert.equal(sum.reasons[0].reason, '(no reason given)');
+  });
+});
+
+describe('mailFilterLogService — byId', () => {
+  it('returns every recipient decision sharing one filtering id', async () => {
+    // The collector dedupes on id + filtering_host + recipient, so one message
+    // to three recipients is three records under one id.
+    writeDay(0, [
+      decision({ id: 'SHARED', recipient: 'a@heroncs.co.uk', status: 'rejected' }),
+      decision({ id: 'SHARED', recipient: 'b@heroncs.co.uk', status: 'accepted' }),
+      decision({ id: 'OTHER', recipient: 'c@heroncs.co.uk' }),
+    ]);
+    const found = await log.byId('SHARED');
+    assert.equal(found.rows.length, 2);
+    assert.ok(found.rows.every((r) => r.id === 'SHARED'));
+  });
+
+  it('does not return partial-id matches', async () => {
+    // The raw-line prefilter is a substring test, so 'ID1' would otherwise
+    // bring back 'ID10' too.
+    writeDay(0, [decision({ id: 'ID1' }), decision({ id: 'ID10' })]);
+    const found = await log.byId('ID1');
+    assert.deepEqual(found.rows.map((r) => r.id), ['ID1']);
+  });
+});
+
+describe('mailFilterLogService — isBlocked', () => {
+  it('recognises the filter vocabulary for stopping mail', () => {
+    for (const s of ['rejected', 'Rejected', 'blocked', 'quarantined', 'deferred', 'discarded']) {
+      assert.equal(log.isBlocked(s), true, `${s} should count as stopped`);
+    }
+    for (const s of ['accepted', 'delivered', 'passed', '', null, undefined]) {
+      assert.equal(log.isBlocked(s), false, `${s} should not count as stopped`);
+    }
+  });
+});

--- a/tests/mailRoutesGuards.test.js
+++ b/tests/mailRoutesGuards.test.js
@@ -1,0 +1,135 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import rbac from '../mongoose/config/rolePermissionsConfig.js';
+import ropa from '../mongoose/config/ropaConfig.js';
+import tiles from '../mongoose/config/dashboardTilesConfig.js';
+
+/**
+ * Config-consistency checks for the mail filtering log. No database, no HTTP.
+ *
+ * Two properties are pinned here, both of which are enforced by absence and so
+ * would otherwise regress silently:
+ *
+ *  1. The module is read-only. It has no write path, and that is the whole
+ *     guarantee — a POST route appearing in mailRoutes.js would quietly turn a
+ *     viewer into an editor of an audit record.
+ *  2. The processing is on the Article 30 register. This is the widest
+ *     category of personal data the platform touches — anyone who emails the
+ *     business — and the register entry is the thing that makes holding it
+ *     defensible.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+/** Source with comments removed, so assertions match code and not prose. */
+const stripComments = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+const routesSrc = read('mongoose/routes/mailRoutes.js');
+const controllerSrc = read('mongoose/controllers/mailFilterController.js');
+const serviceSrc = read('mongoose/services/mailFilterLogService.js');
+const appSrc = read('app.js');
+
+describe('mail routes — read-only by absence', () => {
+  it('registers only GET routes', () => {
+    const verbs = [...routesSrc.matchAll(/router\.(\w+)\(/g)].map((m) => m[1]);
+    assert.ok(verbs.length >= 2, `expected at least 2 routes, found ${verbs.length}`);
+    for (const verb of verbs) {
+      assert.equal(verb, 'get', `mailRoutes.js registers a ${verb.toUpperCase()} route; this module must stay read-only`);
+    }
+  });
+
+  it('registers the expected surface', () => {
+    const paths = [...routesSrc.matchAll(/router\.get\(\s*'([^']+)'/g)].map((m) => m[1]);
+    assert.deepEqual(paths.sort(), ['/mail', '/mail/message/:id']);
+  });
+
+  it('guards every route with admin', () => {
+    const guards = [...routesSrc.matchAll(/router\.get\([^)]*\.\.\.(\w+)/g)].map((m) => m[1]);
+    assert.equal(guards.length, 2);
+    assert.ok(guards.every((g) => g === 'mailGuard'), 'every route must use the shared guard');
+    assert.match(routesSrc, /ensureRole\('admin'\)/);
+    assert.match(routesSrc, /ensureAuthenticated/);
+  });
+
+  it('is mounted in app.js', () => {
+    assert.match(appSrc, /import __mailRoutes from '\.\/mongoose\/routes\/mailRoutes\.js';/);
+    assert.match(appSrc, /appRouter\.use\('\/', __mailRoutes\);/);
+  });
+});
+
+describe('mail routes — permissions registry', () => {
+  it("lists '/mail' in routeAccess as admin only", () => {
+    assert.deepEqual(rbac.routeAccess['/mail'], ['admin']);
+  });
+
+  it('agrees with the guard in the route file', () => {
+    // The two layers disagreeing silently is the failure worth catching: the
+    // middleware would allow a role the route then refuses, or the reverse.
+    const declared = rbac.routeAccess['/mail'];
+    assert.ok(declared.includes('admin'));
+    assert.equal(declared.length, 1, 'widening this is a decision about third-party personal data');
+  });
+
+  it('does not register sub-paths that literal prefix matching would never hit', () => {
+    // matchRoutePattern has no :param support, so '/mail/message/:id' as a
+    // routeAccess key would read as protection that does not exist.
+    const mailKeys = Object.keys(rbac.routeAccess).filter((k) => k.startsWith('/mail'));
+    assert.deepEqual(mailKeys, ['/mail']);
+  });
+
+  it('exposes a dashboard tile pointing at the module', () => {
+    const tile = Object.values(tiles).find((t) => t && t.link === '/mail');
+    assert.ok(tile, 'no dashboard tile links to /mail');
+    assert.deepEqual(tile.department, ['admin']);
+  });
+});
+
+describe('mail filtering log — data handling', () => {
+  it('is on the Article 30 register', () => {
+    const activity = ropa.activities.find((a) => /mail filtering/i.test(a.name));
+    assert.ok(activity, 'inbound mail filtering is not recorded in ropaConfig');
+    assert.equal(activity.retention.startsWith('90 days'), true);
+    assert.ok(activity.lawfulBasis.includes('legitimate_interests'));
+    // The point of the entry: the subject category is anyone who writes to us,
+    // not just people we already hold records for.
+    assert.ok(
+      activity.subjectCategories.includes('any_inbound_correspondent'),
+      'the register must record that this covers arbitrary third parties',
+    );
+  });
+
+  it('names the filtering provider as a processor', () => {
+    const proc = ropa.processors.find((p) => /spamexperts|strikemail/i.test(p.name));
+    assert.ok(proc, 'the mail filtering provider is not listed as a processor');
+  });
+
+  it('never copies the log into Mongo', () => {
+    // Mongo is dumped nightly with its own 90-day archive retention, so
+    // ingesting these records would keep copies alive for ~180 days against a
+    // 90-day policy and take the host deletion job out of the critical path.
+    //
+    // Comments are stripped first: both files explain this decision in prose,
+    // and matching the explanation instead of the code would fail the moment
+    // someone documented it properly.
+    for (const [name, src] of [['service', serviceSrc], ['controller', controllerSrc]]) {
+      const code = stripComments(src);
+      assert.doesNotMatch(code, /mongooseDatabaseService|\bmdb\b|from ['"]mongoose['"]/,
+        `the ${name} must not touch the database`);
+    }
+  });
+
+  it('never builds a RegExp from user input', () => {
+    assert.doesNotMatch(stripComments(serviceSrc), /new RegExp/,
+      'user input compiled into a pattern is a ReDoS vector');
+  });
+
+  it('caps the search window at the collector retention period', async () => {
+    const log = (await import('../mongoose/services/mailFilterLogService.js')).default;
+    assert.equal(log.MAX_DAYS, 90);
+  });
+});

--- a/tests/mailViews.test.js
+++ b/tests/mailViews.test.js
@@ -1,0 +1,217 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
+import ejs from 'ejs';
+
+/**
+ * Renders both mail views with full data, with the bare minimum, and with the
+ * collector absent — mirroring tests/bankViews.test.js. Catches template syntax
+ * errors and unguarded property access with no browser and no filesystem.
+ *
+ * The "collector absent" case is not decoration: it is the state the module
+ * ships in, since hcs-app deploys from a GHCR image and the read-only mount is
+ * added to the stack separately. A page that throws in that state would be the
+ * first thing anyone saw.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VIEWS = path.join(ROOT, 'mongoose/views/tailwindcss/mail');
+
+import dateService from '../services/dateService.js';
+import currencyService from '../services/currencyService.js';
+
+const baseLocals = {
+  csrfToken: 'test-csrf-token',
+  user: { role: 'admin', name: 'Test Admin' },
+  slimDateTime: dateService.slimDateTime,
+  fmtDate: dateService.fmtDate,
+  formatCurrency: currencyService.formatCurrency,
+};
+
+const render = (view, locals) => ejs.renderFile(
+  path.join(VIEWS, `${view}.ejs`),
+  { ...baseLocals, ...locals },
+  { async: false },
+);
+
+const decision = (over = {}) => ({
+  id: 'ID1',
+  filtering_host: 'mx1.eu.spamexperts.com',
+  event_time: '2026-08-21T10:15:02Z',
+  received_at: '2026-08-21T10:15:03Z',
+  sender: 'accounts@acme.co.uk',
+  sender_ip: '203.0.113.45',
+  recipient: 'invoices@heroncs.co.uk',
+  domain: 'heroncs.co.uk',
+  status: 'rejected',
+  main_class: 'Spam',
+  sub_class: 'Bulk',
+  extra_class: 'Quarantine response set to Rejected',
+  raw: 'ID1,mx1.eu.spamexperts.com,2026-08-21 11:15:02,STATUS=rejected',
+  ...over,
+});
+
+const mountedStatus = {
+  mounted: true, dir: '/app/mailsiem/events', files: 30,
+  bytes: 4_500_000, oldest: '2026-07-23', newest: '2026-08-21',
+};
+const absentStatus = {
+  mounted: false, dir: '/app/mailsiem/events', files: 0,
+  bytes: 0, oldest: null, newest: null,
+};
+
+const fullSummary = {
+  mounted: true, days: 7, total: 4210, blocked: 318, truncatedFields: 2,
+  reasons: [
+    { reason: 'Quarantine response set to Rejected', count: 297 },
+    { reason: '(no reason given)', count: 21 },
+  ],
+  byDay: [{ date: '2026-08-21', total: 600, blocked: 40 }],
+};
+const emptySummary = {
+  mounted: true, days: 7, total: 0, blocked: 0, truncatedFields: 0, reasons: [], byDay: [],
+};
+
+const cases = {
+  index: {
+    full: {
+      title: 'Mail Filtering Log', status: mountedStatus, summary: fullSummary,
+      results: {
+        rows: [decision(), decision({ id: 'ID2', status: 'accepted', kv_partial: true, extra_class: 'Rejected' })],
+        mounted: true, truncated: true, scanned: 900, filesScanned: 7, days: 30,
+      },
+      q: 'acme.co.uk', days: 30, blockedOnly: false, maxDays: 90,
+    },
+    minimal: {
+      title: 'Mail Filtering Log', status: mountedStatus, summary: emptySummary,
+      results: null, q: '', days: 30, blockedOnly: false, maxDays: 90,
+    },
+    // The collector is not mounted — the state this ships in.
+    unmounted: {
+      title: 'Mail Filtering Log', status: absentStatus,
+      summary: { mounted: false, days: 7, total: 0, blocked: 0, truncatedFields: 0, reasons: [], byDay: [] },
+      results: null, q: '', days: 30, blockedOnly: false, maxDays: 90,
+    },
+    noResults: {
+      title: 'Mail Filtering Log', status: mountedStatus, summary: emptySummary,
+      results: { rows: [], mounted: true, truncated: false, scanned: 10, filesScanned: 3, days: 30 },
+      q: 'nobody@example.com', days: 30, blockedOnly: false, maxDays: 90,
+    },
+  },
+  message: {
+    full: {
+      title: 'Message ID1', id: 'ID1', status: mountedStatus, mounted: true,
+      rows: [
+        decision({ recipient: 'a@heroncs.co.uk' }),
+        decision({ recipient: 'b@heroncs.co.uk', status: 'accepted', kv_partial: true }),
+      ],
+    },
+    minimal: {
+      title: 'Message ID1', id: 'ID1', status: mountedStatus, mounted: true,
+      rows: [{ id: 'ID1' }],
+    },
+    unmounted: {
+      title: 'Message ID1', id: 'ID1', status: absentStatus, mounted: false, rows: [],
+    },
+    noResults: {
+      title: 'Message ID1', id: 'ID1', status: mountedStatus, mounted: true, rows: [],
+    },
+  },
+};
+
+for (const [view, variants] of Object.entries(cases)) {
+  describe(`mail view: ${view}.ejs`, () => {
+    for (const [name, locals] of Object.entries(variants)) {
+      it(`renders with ${name} data`, async () => {
+        const html = await render(view, locals);
+        assert.ok(html.length > 50, 'rendered almost nothing');
+      });
+    }
+
+    it('contains no inline script, style or event handler', async () => {
+      // Helmet's CSP blocks all three; a violation only shows up as a silently
+      // broken page in production.
+      const html = await render(view, variants.full);
+      assert.ok(!/<script/i.test(html), 'contains a <script> tag');
+      assert.ok(!/<style/i.test(html), 'contains a <style> tag');
+      assert.ok(!/\son(click|change|submit|load|input)\s*=/i.test(html), 'contains an inline event handler');
+      assert.ok(!/\b(fetch|XMLHttpRequest|axios)\s*\(/.test(html), 'contains a browser network call');
+    });
+
+    it('is a fragment, not a full page', async () => {
+      const html = await render(view, variants.full);
+      for (const tag of ['<html', '<head', '<body', '<nav']) {
+        assert.ok(!html.toLowerCase().includes(tag), `contains ${tag}`);
+      }
+    });
+
+    it('has no mutating form', async () => {
+      // Read-only by absence, asserted at the view layer too: a POST form here
+      // would need CSRF, and there is no route to receive it.
+      const html = await render(view, variants.full);
+      assert.ok(!/method\s*=\s*["']post["']/i.test(html), 'contains a POST form');
+    });
+  });
+}
+
+describe('mail view: index.ejs — states that must be distinguishable', () => {
+  it('says the collector is not mounted rather than showing an empty log', async () => {
+    const html = await render('index', cases.index.unmounted);
+    assert.match(html, /Collector not mounted/i);
+    // An empty log and an absent one mean very different things.
+    assert.ok(!/Nothing was stopped in this window/i.test(html));
+  });
+
+  it('does not list decisions before a search term is given', async () => {
+    const html = await render('index', cases.index.minimal);
+    assert.match(html, /Enter a search term/i);
+  });
+
+  it('shows the reason a message was stopped', async () => {
+    const html = await render('index', cases.index.full);
+    assert.match(html, /Quarantine response set to Rejected/);
+  });
+
+  it('flags truncated field values', async () => {
+    const html = await render('index', cases.index.full);
+    assert.match(html, /\[truncated\]/i);
+    assert.match(html, /needs quoting support/i);
+  });
+
+  it('says when results were capped', async () => {
+    const html = await render('index', cases.index.full);
+    assert.match(html, /Showing the first/i);
+  });
+
+  it('escapes values rather than interpolating them raw', async () => {
+    const html = await render('index', {
+      ...cases.index.full,
+      results: { ...cases.index.full.results, rows: [decision({ sender: '<img src=x onerror=alert(1)>' })] },
+    });
+    // These records are attacker-influenced: the sender chooses their own
+    // address and HELO string.
+    assert.ok(!html.includes('<img src=x'), 'sender was interpolated unescaped');
+    assert.match(html, /&lt;img/);
+  });
+});
+
+describe('mail view: message.ejs', () => {
+  it('explains that one message can be several decisions', async () => {
+    const html = await render('message', cases.message.full);
+    assert.match(html, /addressed to <strong>2<\/strong> recipients/i);
+  });
+
+  it('offers the original syslog line', async () => {
+    const html = await render('message', cases.message.full);
+    assert.match(html, /Original syslog line/i);
+  });
+
+  it('escapes the raw line', async () => {
+    const html = await render('message', {
+      ...cases.message.full,
+      rows: [decision({ raw: '<script>alert(1)</script>' })],
+    });
+    assert.ok(!/<script>alert/i.test(html), 'raw line was interpolated unescaped');
+  });
+});


### PR DESCRIPTION
Inbound mail to heroncs.co.uk was being silently rejected by the SpamExperts/StrikeMail filter — Quarantine response was set to **Rejected**, so legitimate senders got a 550 and we never saw it. There was no local record of any of it, which made *"did my email reach you?"* a support ticket rather than a question anyone here could answer.

The `mailsiem` collector on server2-host now receives a syslog line per filtering decision and writes one NDJSON file per day. **This PR is hcs-app's read-only window onto those files.**

## What it adds

- **`/mail`** (admin only) — how much mail was stopped, **why**, and a search across sender, recipient, sending IP, message-id and filtering id.
- **`/mail/message/:id`** — every decision recorded under one filtering id. A message to several recipients is several decisions, and they can differ: one recipient's mail can be delivered while another's is stopped.
- `ropaConfig` **A8** — the processing on the Article 30 register.

`extra_class` is the filter's own account of a classification, and it gets a column of its own: a run of identical reasons across unrelated senders is what a misconfigured quarantine response looks like from the outside. That is the fault this whole pipeline exists to surface.

## The log is deliberately not in Mongo

**Please don't "improve" this by ingesting it into a collection.** These records are third-party personal data — every line names a sender and a recipient, including people who appear nowhere else in this system and never chose to deal with us — held under a 90-day rule enforced by a deletion job on the collector host.

Mongo is dumped nightly with its own 90-day archive retention, and those archives are browsable. Ingesting would leave copies alive for up to **~180 days against a 90-day policy**, and the deletion job would stop being the single thing that makes the policy true. Reading the files keeps the collector the sole owner: when a day file is deleted it is gone everywhere, including here.

`mailFilterLogService.js` touches no database. A test strips comments and asserts neither the service nor the controller contains a database call — both files *explain* this decision in prose, and matching the explanation rather than the code would fail the moment someone documented it properly.

Two consequences worth noting: because there is no model, **there is no fourth-namespace Mongo grant to forget** (the trap `hcs-webdb` fell into in 6.27.0), and `requiredSchemasVersion` stays 3.0.0, so the three-step `hcs-schemas` deploy does not apply.

## Design notes

**Every query is a bounded scan** — no index exists. The window is capped at the collector's 90-day retention, the landing-page summary uses its own narrower 7-day window rather than being widened by the search, and a bare page load scans nothing and lists nothing (returning "the most recent hundred" would invite reading it as a complete list). Lines are filtered as **raw text before `JSON.parse`**, which is what makes this fast enough to be a page. Measured at 12,000 decisions across three day files: summary ~65 ms, search ~40 ms.

**The search term is a substring test and never a `RegExp`.** User input compiled into a pattern is a ReDoS vector and none of these lookups need patterns; a test asserts `new RegExp` does not appear in the service.

**Read-only by absence.** The module registers `GET` routes and nothing else — the same enforcement style as the missing KashFlow wrappers in hcs-sync and the read-only content API in the website module. It is not that writes are disabled; there is no route to receive one, which is also why nothing here needs CSRF. A test fails if any other verb appears in `mailRoutes.js`, and the views are asserted to contain no `POST` form.

**Admin only, which is narrower than the finance department pattern used by `/bank`,** because the subject category here is anyone who writes to the business. Widening it is one entry in `routeAccess` plus the route guard, and should be a decision rather than a drift; a test pins the entry to exactly `['admin']`.

**Sender-controlled values are escaped, and asserted to be.** The sender chooses their own address and HELO string, so these records are attacker-influenced in a way most of this app's data is not.

## Deployment

Needs a read-only bind mount; **without it the page says so rather than breaking.**

```yaml
volumes:
  - /mnt/data/mailsiem/events:/app/mailsiem/events:ro
```

`docker-compose.yml` and `compose.env.example` are updated (`MAILSIEM_HOST_DIR` / `MAILSIEM_EVENTS_DIR`). The mount must stay read-only — hcs-app runs as root and would otherwise happily write into the collector's directory.

Unmounted is a **supported state**, and the one this ships in, since the image deploys before any stack change: `/mail` renders a "collector not mounted" banner, deliberately a different message from an empty log. Both states are covered by tests.

On server2-host, `docker/app/docker-compose.yml` is already patched with the mount but the container has **not** been recreated — the file is intentionally ahead of the running container by exactly that mount, so the next `docker compose pull && up -d` applies image and mount together.

## Tests

54 new tests across three files — service behaviour against real temporary NDJSON, config/permissions consistency, and both views rendered with full, minimal, empty and unmounted data.

Suite: **1320 → 1374, 0 failures, exit 0.**
