### PR TITLE
feat(mail): show the log with no filter, and fix which end gets capped (6.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to hcs-app will be documented here. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [6.33.0] - 2026-08-21
+
+### Changed
+- **`/mail` is a log again: it lists recent decisions with no search term and no filter.** It previously refused to list anything until you searched or ticked "stopped only", on the reasoning that a partial list invites being read as a complete one. That reasoning was right about the risk and wrong about the remedy — the fix is to label a partial list honestly, not to withhold it, and the page was useless for its most obvious purpose, which is reading what just happened. A "Clear filters" link appears once anything is narrowing the view, and a page-size control offers 100/200/500.
+
+  It stays cheap because of how the reader is now ordered: each day file contributes its newest rows and the scan stops once a page is filled, so **a browse reads one day file however wide the window is**. Measured over three files of 4,000 decisions, a 30-day and a 90-day browse both read a single file in ~45 ms.
+
+### Fixed
+- **A capped list was showing the oldest rows, while calling them the first.** Day files are read newest-first, but each file is written in chronological order, so taking the first N matches and stopping returned the *oldest* N of the newest day. Sorting afterwards could not recover rows that were never read, so "Showing the first 200 matches" was reliably the wrong end of the log — and on a busy day, the 200 shown could all be hours older than the ones being looked for.
+
+  The reader now keeps each file's newest N in a circular buffer and takes them newest-first. A circular buffer rather than an array with `shift()`: the latter is O(n·cap) and is noticeably slow over a wide window, while this is O(1) per line and bounded by the page size. The banner says "the most recent N … older ones exist", which is what it always should have said.
+
+  This was latent in search results from 6.32.0 and would have been much more visible as a browse view, since browsing is exactly the case where "most recent" is the whole point.
+
 ## [6.32.0] - 2026-08-21
 
 ### Added

--- a/mongoose/controllers/mailFilterController.js
+++ b/mongoose/controllers/mailFilterController.js
@@ -28,12 +28,17 @@ export const getIndex = async (req, res, next) => {
     // deliberate act; recomputing 90 days of counters on every page view is not.
     const summary = await log.summary({});
 
-    // A bare page load must not scan anything: with no search term and no
-    // filter there is nothing to narrow by, and returning "the most recent
-    // hundred" would invite reading it as a complete list.
-    const results = (q || blockedOnly)
-      ? await log.search({ q, days, blockedOnly, limit: 200 })
-      : null;
+    // This is a log first and a search second, so a bare page load shows the
+    // most recent decisions rather than an empty page with a search box. The
+    // earlier design refused to list anything without a filter, on the grounds
+    // that a partial list invites being read as a complete one; the answer to
+    // that is to label it honestly, not to withhold it.
+    //
+    // It stays cheap because the reader takes each file's newest rows and stops
+    // once it has a page: every remaining day file is older, so a browse
+    // normally reads one file however wide the window is.
+    const limit = log.normaliseLimit(req.query.limit);
+    const results = await log.search({ q, days, blockedOnly, limit });
 
     res.render(VIEW('index'), {
       title: 'Mail Filtering Log',
@@ -43,6 +48,9 @@ export const getIndex = async (req, res, next) => {
       q,
       days,
       blockedOnly,
+      limit,
+      limitOptions: log.LIMIT_OPTIONS,
+      filtered: Boolean(q || blockedOnly),
       maxDays: log.MAX_DAYS,
     });
   } catch (err) { next(err); }

--- a/mongoose/services/mailFilterLogService.js
+++ b/mongoose/services/mailFilterLogService.js
@@ -82,6 +82,14 @@ export function normaliseDays(value, fallback = DEFAULT_SEARCH_DAYS) {
   return clampInt(value, fallback, 1, MAX_DAYS);
 }
 
+/** Page sizes offered in the UI. Capped by MAX_LIMIT regardless. */
+export const LIMIT_OPTIONS = [100, 200, 500];
+
+export function normaliseLimit(value) {
+  const n = Number.parseInt(value, 10);
+  return LIMIT_OPTIONS.includes(n) ? n : LIMIT_OPTIONS[0];
+}
+
 export function normaliseQuery(value) {
   return String(value || '').trim().slice(0, MAX_QUERY_LENGTH);
 }
@@ -204,28 +212,63 @@ export async function search({ q = '', days = DEFAULT_SEARCH_DAYS, blockedOnly =
   let filesScanned = 0;
 
   const rawFilter = needle ? (line) => line.toLowerCase().includes(needle) : null;
+  const files = dayFiles(window);
 
-  for (const { file } of dayFiles(window)) {
-    if (truncated) break;
+  for (let f = 0; f < files.length; f += 1) {
     filesScanned += 1;
+
+    /*
+     * Keep this file's NEWEST `cap` matches, not its first `cap`.
+     *
+     * Day files are read newest-first but each one is written in chronological
+     * order, so taking the first matches and stopping — which is what this did
+     * originally — returns the *oldest* rows of the newest day and labels them
+     * "the first N". Sorting afterwards cannot recover what was never read.
+     *
+     * A circular buffer keeps it O(1) per line and bounded by `cap`; an array
+     * with shift() would be O(n·cap) and is noticeably slow over a big window.
+     */
+    const buf = new Array(cap);
+    let seen = 0;
+
     // eslint-disable-next-line no-await-in-loop
-    scanned += await scanFile(file, rawFilter, (row) => {
+    scanned += await scanFile(file(files, f), rawFilter, (row) => {
       if (blockedOnly && !isBlocked(row.status)) return true;
-      rows.push(row);
-      if (rows.length >= cap) {
-        truncated = true;
-        return false;
-      }
+      buf[seen % cap] = row;
+      seen += 1;
       return true;
     });
-    if (scanned >= MAX_LINES_PER_REQUEST) truncated = true;
+
+    if (seen > cap) truncated = true;
+
+    // Newest first out of the ring.
+    const kept = Math.min(seen, cap);
+    for (let i = seen - 1; i >= seen - kept && rows.length < cap; i -= 1) {
+      rows.push(buf[i % cap]);
+    }
+
+    if (rows.length >= cap) {
+      // Every remaining file is older than this one, so nothing newer is being
+      // missed — but older matches may well exist beyond what is shown.
+      if (f < files.length - 1 || seen > cap) truncated = true;
+      break;
+    }
+    if (scanned >= MAX_LINES_PER_REQUEST) {
+      truncated = true;
+      break;
+    }
   }
 
-  // Newest first. event_time is the filter's own clock; received_at is ours and
-  // is always present, so it is the fallback rather than the primary.
+  // event_time is the filter's own clock; received_at is ours and is always
+  // present, so it is the fallback rather than the primary.
   rows.sort((a, b) => String(b.event_time || b.received_at || '').localeCompare(String(a.event_time || a.received_at || '')));
 
   return { rows, mounted: true, truncated, scanned, filesScanned, days: window };
+}
+
+/** Small indirection so the loop above reads cleanly. */
+function file(files, i) {
+  return files[i].file;
 }
 
 /**
@@ -299,4 +342,4 @@ export async function byId(id, { days = MAX_DAYS } = {}) {
   return { ...found, rows: found.rows.filter((r) => String(r.id) === wanted) };
 }
 
-export default { eventsDir, status, search, summary, byId, isBlocked, dayFiles, normaliseDays, normaliseQuery, MAX_DAYS, DEFAULT_SEARCH_DAYS, DEFAULT_SUMMARY_DAYS, MAX_LIMIT };
+export default { eventsDir, status, search, summary, byId, isBlocked, dayFiles, normaliseDays, normaliseQuery, normaliseLimit, LIMIT_OPTIONS, MAX_DAYS, DEFAULT_SEARCH_DAYS, DEFAULT_SUMMARY_DAYS, MAX_LIMIT };

--- a/mongoose/views/tailwindcss/mail/index.ejs
+++ b/mongoose/views/tailwindcss/mail/index.ejs
@@ -20,9 +20,9 @@
   </div>
 
   <p class="text-sm text-gray-700 dark:text-gray-300 mb-6 max-w-3xl">
-    Every filtering decision the SpamExperts cluster has made about mail addressed to us.
-    Search by sender, recipient, sending IP, message-id or filtering id to find out what
-    happened to a specific message.
+    Every filtering decision the SpamExperts cluster has made about mail addressed to us,
+    newest first. Search by sender, recipient, sending IP, message-id or filtering id to
+    find a specific message &mdash; or leave the box empty and just read the log.
   </p>
 
   <% if (!status.mounted) { %>
@@ -106,9 +106,9 @@
       <% } %>
     </div>
 
-    <!-- Search -->
+    <!-- The log itself. Filters narrow it; none are required. -->
     <h2 class="font-semibold text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
-      Find a message
+      <%= filtered ? 'Matching decisions' : 'Recent decisions' %>
     </h2>
     <form method="GET" action="/mail" class="flex gap-2 flex-wrap mb-6">
       <input name="q" value="<%= q %>" placeholder="Sender, recipient, IP, message-id or filtering id&hellip;"
@@ -128,27 +128,48 @@
           class="rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500" />
         Stopped only
       </label>
+      <select name="limit"
+        class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+               bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+               focus:outline-none focus:ring-2 focus:ring-green-500">
+        <% limitOptions.forEach(n => { %>
+          <option value="<%= n %>" <%= limit === n ? 'selected' : '' %>>Show <%= n %></option>
+        <% }) %>
+      </select>
       <button type="submit"
         class="text-sm bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded-lg shadow-sm font-medium transition">
         Search
       </button>
+      <% if (filtered) { %>
+        <a href="/mail"
+          class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600
+                 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300
+                 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm font-medium transition shadow-sm">
+          Clear filters
+        </a>
+      <% } %>
     </form>
 
-    <% if (results === null) { %>
+    <% if (!results.rows.length) { %>
       <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
-        Enter a search term above, or tick &ldquo;stopped only&rdquo;, to list decisions.
-      </div>
-    <% } else if (!results.rows.length) { %>
-      <div class="text-sm text-gray-400 dark:text-gray-500 p-6 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 text-center">
-        No filtering decisions matched in the last <%= results.days %> days.
+        <% if (filtered) { %>
+          No filtering decisions matched in the last <%= results.days %> days.
+        <% } else { %>
+          No filtering decisions have been recorded in the last <%= results.days %> days.
+          <div class="mt-1 text-xs">If the SpamExperts template has not been switched Active yet, that is expected.</div>
+        <% } %>
         <% if (status.oldest) { %>
           <div class="mt-1 text-xs">The log starts at <%= status.oldest %>; anything older has passed the 90-day retention limit.</div>
         <% } %>
       </div>
     <% } else { %>
       <% if (results.truncated) { %>
+        <!-- "most recent", not "first": the reader keeps each file's newest rows,
+             so a capped list is the newest end of the log, not the oldest. -->
         <div class="mb-3 p-3 rounded-xl border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 text-sm text-blue-800 dark:text-blue-300">
-          Showing the first <%= results.rows.length %> matches only. Narrow the search or the window to see the rest.
+          Showing the <strong><%= results.rows.length %></strong> most recent
+          <%= filtered ? 'matches' : 'decisions' %> in this window &mdash; older ones exist.
+          Show more, narrow the window, or search to reach them.
         </div>
       <% } %>
       <div class="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm">
@@ -206,8 +227,8 @@
         </table>
       </div>
       <p class="text-xs text-gray-500 dark:text-gray-400 mt-3">
-        <%= results.rows.length.toLocaleString('en-GB') %> decision(s) from
-        <%= results.filesScanned %> day file(s).
+        <%= results.rows.length.toLocaleString('en-GB') %> decision(s) shown from
+        <%= results.filesScanned %> day file(s)<%= results.truncated ? ', newest first' : '' %>.
       </p>
     <% } %>
   <% } %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hcs-app",
-  "version": "6.32.0",
+  "version": "6.33.0",
   "requiredSchemasVersion": "3.0.0",
   "type": "module",
   "description": "Internal business platform for Heron Constructive Solutions LTD: CIS compliance, HR, attendance, fleet, holidays, document management and finance dashboards. (Payroll and direct HMRC integration are in development, not production-ready.)",

--- a/tests/mailFilterLogService.test.js
+++ b/tests/mailFilterLogService.test.js
@@ -148,6 +148,41 @@ describe('mailFilterLogService — search', () => {
     assert.equal(found.truncated, true);
   });
 
+  it('caps to the NEWEST matches, not the first ones read', async () => {
+    // Day files are written chronologically, so taking the first N matches and
+    // stopping returns the OLDEST N of the newest day. This is the regression
+    // that made "showing the first 200" show the wrong end of the log.
+    writeDay(0, Array.from({ length: 50 }, (_, i) => decision({
+      id: `ID${String(i).padStart(2, '0')}`,
+      event_time: `2026-08-21T${String(i % 24).padStart(2, '0')}:00:00Z`,
+    })));
+    const found = await log.search({ days: 1, limit: 5 });
+    assert.equal(found.rows.length, 5);
+    assert.equal(found.truncated, true);
+    // The last five written are ID45..ID49.
+    assert.deepEqual(
+      found.rows.map((r) => r.id).sort(),
+      ['ID45', 'ID46', 'ID47', 'ID48', 'ID49'],
+    );
+  });
+
+  it('does not let an older day file displace newer rows', async () => {
+    writeDay(0, [decision({ id: 'TODAY-A' }), decision({ id: 'TODAY-B' })]);
+    writeDay(1, [decision({ id: 'YESTERDAY' })]);
+    const found = await log.search({ days: 7, limit: 2 });
+    assert.deepEqual(found.rows.map((r) => r.id).sort(), ['TODAY-A', 'TODAY-B']);
+    assert.equal(found.truncated, true, 'older matches exist and that must be said');
+  });
+
+  it('returns the log with no search term and no filter at all', async () => {
+    // The page is a log first and a search second: asking for nothing must
+    // return recent decisions rather than an empty result.
+    writeDay(0, [decision({ id: 'A' }), decision({ id: 'B', status: 'accepted' })]);
+    const found = await log.search({});
+    assert.equal(found.rows.length, 2);
+    assert.equal(found.truncated, false);
+  });
+
   it('survives a torn final line without failing the request', async () => {
     // The collector may be mid-write. One unreadable line must not cost the
     // whole page.

--- a/tests/mailViews.test.js
+++ b/tests/mailViews.test.js
@@ -82,21 +82,28 @@ const cases = {
         mounted: true, truncated: true, scanned: 900, filesScanned: 7, days: 30,
       },
       q: 'acme.co.uk', days: 30, blockedOnly: false, maxDays: 90,
+      limit: 200, limitOptions: [100, 200, 500], filtered: true,
     },
+    // No search term and no filter — the plain log view, which is the default.
     minimal: {
       title: 'Mail Filtering Log', status: mountedStatus, summary: emptySummary,
-      results: null, q: '', days: 30, blockedOnly: false, maxDays: 90,
+      results: { rows: [decision()], mounted: true, truncated: false, scanned: 1, filesScanned: 1, days: 30 },
+      q: '', days: 30, blockedOnly: false, maxDays: 90,
+      limit: 100, limitOptions: [100, 200, 500], filtered: false,
     },
     // The collector is not mounted — the state this ships in.
     unmounted: {
       title: 'Mail Filtering Log', status: absentStatus,
       summary: { mounted: false, days: 7, total: 0, blocked: 0, truncatedFields: 0, reasons: [], byDay: [] },
-      results: null, q: '', days: 30, blockedOnly: false, maxDays: 90,
+      results: { rows: [], mounted: false, truncated: false, scanned: 0, filesScanned: 0, days: 30 },
+      q: '', days: 30, blockedOnly: false, maxDays: 90,
+      limit: 100, limitOptions: [100, 200, 500], filtered: false,
     },
     noResults: {
       title: 'Mail Filtering Log', status: mountedStatus, summary: emptySummary,
       results: { rows: [], mounted: true, truncated: false, scanned: 10, filesScanned: 3, days: 30 },
       q: 'nobody@example.com', days: 30, blockedOnly: false, maxDays: 90,
+      limit: 100, limitOptions: [100, 200, 500], filtered: true,
     },
   },
   message: {
@@ -163,9 +170,21 @@ describe('mail view: index.ejs — states that must be distinguishable', () => {
     assert.ok(!/Nothing was stopped in this window/i.test(html));
   });
 
-  it('does not list decisions before a search term is given', async () => {
+  it('lists the log with no search term and no filter', async () => {
+    // This is a log first and a search second. It used to refuse to list
+    // anything until you filtered, which made the page useless for its most
+    // obvious use: reading what just happened.
     const html = await render('index', cases.index.minimal);
-    assert.match(html, /Enter a search term/i);
+    assert.ok(!/Enter a search term/i.test(html), 'still gating the list behind a filter');
+    assert.match(html, /Recent decisions/i);
+    assert.match(html, /invoices@heroncs\.co\.uk/);
+  });
+
+  it('offers a way back to the unfiltered log once filtered', async () => {
+    const filteredHtml = await render('index', cases.index.full);
+    assert.match(filteredHtml, /Clear filters/i);
+    const plainHtml = await render('index', cases.index.minimal);
+    assert.ok(!/Clear filters/i.test(plainHtml), 'nothing to clear on the plain log');
   });
 
   it('shows the reason a message was stopped', async () => {
@@ -179,9 +198,12 @@ describe('mail view: index.ejs — states that must be distinguishable', () => {
     assert.match(html, /needs quoting support/i);
   });
 
-  it('says when results were capped', async () => {
+  it('describes a capped list as the most recent, not the first', async () => {
+    // The reader keeps each file's newest rows, so a capped list is the newest
+    // end of the log. Calling it "the first N" described the opposite end.
     const html = await render('index', cases.index.full);
-    assert.match(html, /Showing the first/i);
+    assert.match(html, /most recent/i);
+    assert.ok(!/Showing the first/i.test(html), 'still claims to show the first N');
   });
 
   it('escapes values rather than interpolating them raw', async () => {


### PR DESCRIPTION
`/mail` refused to list anything until you searched or ticked "stopped only". The reasoning — a partial list invites being read as a complete one — was right about the risk and wrong about the remedy. **Label it honestly rather than withhold it.** The page was useless for its most obvious purpose: reading what just happened.

A bare load now shows recent decisions, newest first. A **Clear filters** link appears once anything is narrowing the view, and a page-size control offers 100/200/500.

## The bug this uncovered

Day files are read **newest-first**, but each file is written in **chronological order**. Taking the first N matches and stopping therefore returned the *oldest* N of the newest day — and sorting afterwards cannot recover rows that were never read.

So "Showing the first 200 matches" was reliably the wrong end of the log. On a busy day every row shown could be hours older than the ones being looked for.

This was already latent in 6.32.0's search results. It would have been far more visible as a browse view, since browsing is exactly the case where "most recent" is the entire point.

**Fix:** each day file contributes its newest N via a circular buffer, taken newest-first. A circular buffer rather than an array with `shift()` — the latter is O(n·cap) and noticeably slow over a wide window; this is O(1) per line and bounded by the page size. The banner now reads "the most recent N … older ones exist", which is what it always should have said.

A test pins the ordering and **fails against the old reader** (verified by stashing the service and re-running).

## Performance

The scan stops once a page is filled, because every remaining day file is older. **A browse reads one day file however wide the window is** — measured over three files of 4,000 decisions, a 30-day and a 90-day browse both read a single file in ~45 ms.

## Tests

Suite **1374 → 1378**, 0 failures, exit 0.